### PR TITLE
fix: deployer config validation and CCIP native token mapping

### DIFF
--- a/src/JBCCIPSucker.sol
+++ b/src/JBCCIPSucker.sol
@@ -250,6 +250,15 @@ contract JBCCIPSucker is JBSucker, IAny2EVMMessageReceiver {
         // This sucker has an override since it could connect to a non-ETH chain, so we allow the `NATIVE_TOKEN` to map
         // to a token that is not the wrapped token on the remote.
 
+        // If the local token is the native token, the remote token must also be the native token or address(0) to
+        // disable.
+        if (
+            map.localToken == JBConstants.NATIVE_TOKEN && map.remoteToken != JBConstants.NATIVE_TOKEN
+                && map.remoteToken != address(0)
+        ) {
+            revert JBSucker_InvalidNativeRemoteAddress(map.remoteToken);
+        }
+
         // Enforce a reasonable minimum gas limit for bridging. A minimum which is too low could lead to the loss of
         // funds.
         if (map.minGas < MESSENGER_ERC20_MIN_GAS_LIMIT && map.localToken != JBConstants.NATIVE_TOKEN) {

--- a/src/deployers/JBArbitrumSuckerDeployer.sol
+++ b/src/deployers/JBArbitrumSuckerDeployer.sol
@@ -49,8 +49,8 @@ contract JBArbitrumSuckerDeployer is JBSuckerDeployer, IJBArbitrumSuckerDeployer
 
     /// @notice Check if the layer specific configuration is set or not. Used as a sanity check.
     function _layerSpecificConfigurationIsSet() internal view override returns (bool) {
-        return uint256(arbLayer) != uint256(0) || address(arbInbox) != address(0)
-            || address(arbGatewayRouter) != address(0);
+        return uint256(arbLayer) != uint256(0) && address(arbInbox) != address(0)
+            && address(arbGatewayRouter) != address(0);
     }
 
     //*********************************************************************//

--- a/src/deployers/JBOptimismSuckerDeployer.sol
+++ b/src/deployers/JBOptimismSuckerDeployer.sol
@@ -47,7 +47,7 @@ contract JBOptimismSuckerDeployer is JBSuckerDeployer, IJBOpSuckerDeployer {
 
     /// @notice Check if the layer specific configuration is set or not. Used as a sanity check.
     function _layerSpecificConfigurationIsSet() internal view override returns (bool) {
-        return address(opMessenger) != address(0) || address(opBridge) != address(0);
+        return address(opMessenger) != address(0) && address(opBridge) != address(0);
     }
 
     //*********************************************************************//


### PR DESCRIPTION
- JBOptimismSuckerDeployer: change || to && so partial config is rejected
- JBArbitrumSuckerDeployer: change || to && so partial config is rejected
- JBCCIPSucker: restore native token mapping constraint (NATIVE_TOKEN can only map to NATIVE_TOKEN or address(0) to disable)

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: