### PR TITLE
fix: deployer config validation and CCIP token mapping

### DIFF
--- a/src/JBCCIPSucker.sol
+++ b/src/JBCCIPSucker.sol
@@ -250,6 +250,15 @@ contract JBCCIPSucker is JBSucker, IAny2EVMMessageReceiver {
         // This sucker has an override since it could connect to a non-ETH chain, so we allow the `NATIVE_TOKEN` to map
         // to a token that is not the wrapped token on the remote.
 
+        // If the local token is the native token, the remote token must also be the native token or address(0) to
+        // disable.
+        if (
+            map.localToken == JBConstants.NATIVE_TOKEN && map.remoteToken != JBConstants.NATIVE_TOKEN
+                && map.remoteToken != address(0)
+        ) {
+            revert JBSucker_InvalidNativeRemoteAddress(map.remoteToken);
+        }
+
         // Enforce a reasonable minimum gas limit for bridging. A minimum which is too low could lead to the loss of
         // funds.
         if (map.minGas < MESSENGER_ERC20_MIN_GAS_LIMIT && map.localToken != JBConstants.NATIVE_TOKEN) {

--- a/src/JBCCIPSucker.sol
+++ b/src/JBCCIPSucker.sol
@@ -134,8 +134,10 @@ contract JBCCIPSucker is JBSucker, IAny2EVMMessageReceiver {
 
         // We either send no tokens or a single token.
         if (any2EvmMessage.destTokenAmounts.length == 1) {
-            // As far as the sucker contract is aware wrapped natives are not a thing, it only handles ERC20s or native.
+            // The sucker only handles ERC-20s or native. CCIP delivers wrapped native (WETH).
             Client.EVMTokenAmount memory tokenAmount = any2EvmMessage.destTokenAmounts[0];
+            // Unwrap WETH -> ETH only when the root says the token is NATIVE_TOKEN.
+            // When root.token is an ERC-20 address (e.g., bridging to a chain where ETH is an ERC-20), no unwrap.
             if (root.token == JBConstants.NATIVE_TOKEN) {
                 // We can (safely) assume that the token that is set in the `destTokenAmounts` is a valid wrapped
                 // native.
@@ -194,7 +196,8 @@ contract JBCCIPSucker is JBSucker, IAny2EVMMessageReceiver {
             // If we also do an asset transfer then we increase the min required gas amount.
             gasLimit += remoteToken.minGas;
 
-            // Wrap the token if it's native
+            // Wrap native ETH -> WETH for CCIP bridging. CCIP only transports ERC-20s.
+            // This is why `_validateTokenMapping` enforces minGas for native tokens too.
             if (token == JBConstants.NATIVE_TOKEN) {
                 // Get the wrapped native token.
                 // slither-disable-next-line calls-loop
@@ -246,22 +249,22 @@ contract JBCCIPSucker is JBSucker, IAny2EVMMessageReceiver {
     }
 
     /// @notice Allow sucker implementations to add/override mapping rules to suite their specific needs.
+    /// @dev Unlike OP/Arbitrum suckers (which share ETH as native on both chains), this CCIP sucker can connect
+    /// chains with different native tokens. This means `NATIVE_TOKEN` may map to an ERC-20 on the remote chain.
+    ///
+    /// Example: ETH mainnet (native = ETH) <-> Celo (native = CELO, ETH is an ERC-20).
+    ///   - On mainnet: `mapToken({localToken: NATIVE_TOKEN, remoteToken: celoETH_address})`
+    ///   - Sending: `_sendRootOverAMB` wraps native ETH -> WETH, bridges WETH via CCIP.
+    ///   - Receiving: `ccipReceive` checks `root.token == NATIVE_TOKEN` to decide whether to unwrap WETH -> ETH.
+    ///     If `root.token` is an ERC-20 address (like celoETH), no unwrap occurs — tokens stay as ERC-20.
+    ///
+    /// The base class restriction (`NATIVE_TOKEN` can only map to `NATIVE_TOKEN` or `address(0)`) is intentionally
+    /// removed here. The base class retains that restriction for OP/Arbitrum where both chains share ETH as native.
     function _validateTokenMapping(JBTokenMapping calldata map) internal pure virtual override {
-        // This sucker has an override since it could connect to a non-ETH chain, so we allow the `NATIVE_TOKEN` to map
-        // to a token that is not the wrapped token on the remote.
-
-        // If the local token is the native token, the remote token must also be the native token or address(0) to
-        // disable.
-        if (
-            map.localToken == JBConstants.NATIVE_TOKEN && map.remoteToken != JBConstants.NATIVE_TOKEN
-                && map.remoteToken != address(0)
-        ) {
-            revert JBSucker_InvalidNativeRemoteAddress(map.remoteToken);
-        }
-
         // Enforce a reasonable minimum gas limit for bridging. A minimum which is too low could lead to the loss of
-        // funds.
-        if (map.minGas < MESSENGER_ERC20_MIN_GAS_LIMIT && map.localToken != JBConstants.NATIVE_TOKEN) {
+        // funds. CCIP wraps native tokens to WETH before bridging (see `_sendRootOverAMB`), so ALL tokens —
+        // including native — need sufficient gas for an ERC-20 transfer on the remote chain.
+        if (map.minGas < MESSENGER_ERC20_MIN_GAS_LIMIT) {
             revert JBSucker_BelowMinGas(map.minGas, MESSENGER_ERC20_MIN_GAS_LIMIT);
         }
     }

--- a/src/deployers/JBArbitrumSuckerDeployer.sol
+++ b/src/deployers/JBArbitrumSuckerDeployer.sol
@@ -49,8 +49,9 @@ contract JBArbitrumSuckerDeployer is JBSuckerDeployer, IJBArbitrumSuckerDeployer
 
     /// @notice Check if the layer specific configuration is set or not. Used as a sanity check.
     function _layerSpecificConfigurationIsSet() internal view override returns (bool) {
-        return uint256(arbLayer) != uint256(0) || address(arbInbox) != address(0)
-            || address(arbGatewayRouter) != address(0);
+        // We don't check arbLayer here because JBLayer.L1 == 0 which is the default/unset value.
+        // Since all fields are set atomically in setChainSpecificConstants, checking inbox + gateway is sufficient.
+        return address(arbInbox) != address(0) && address(arbGatewayRouter) != address(0);
     }
 
     //*********************************************************************//

--- a/src/deployers/JBOptimismSuckerDeployer.sol
+++ b/src/deployers/JBOptimismSuckerDeployer.sol
@@ -47,6 +47,8 @@ contract JBOptimismSuckerDeployer is JBSuckerDeployer, IJBOpSuckerDeployer {
 
     /// @notice Check if the layer specific configuration is set or not. Used as a sanity check.
     function _layerSpecificConfigurationIsSet() internal view override returns (bool) {
+        // Use && (not ||) so the post-set check in setChainSpecificConstants rejects partial configurations
+        // where only one of messenger/bridge is provided. Both are required for the sucker to function.
         return address(opMessenger) != address(0) && address(opBridge) != address(0);
     }
 

--- a/src/deployers/JBOptimismSuckerDeployer.sol
+++ b/src/deployers/JBOptimismSuckerDeployer.sol
@@ -47,7 +47,7 @@ contract JBOptimismSuckerDeployer is JBSuckerDeployer, IJBOpSuckerDeployer {
 
     /// @notice Check if the layer specific configuration is set or not. Used as a sanity check.
     function _layerSpecificConfigurationIsSet() internal view override returns (bool) {
-        return address(opMessenger) != address(0) || address(opBridge) != address(0);
+        return address(opMessenger) != address(0) && address(opBridge) != address(0);
     }
 
     //*********************************************************************//

--- a/test/unit/ccip_native_interop.t.sol
+++ b/test/unit/ccip_native_interop.t.sol
@@ -1,0 +1,689 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {Client} from "@chainlink/contracts-ccip/src/v0.8/ccip/libraries/Client.sol";
+import {IRouterClient} from "@chainlink/contracts-ccip/src/v0.8/ccip/interfaces/IRouterClient.sol";
+import {IJBDirectory} from "@bananapus/core-v5/src/interfaces/IJBDirectory.sol";
+import {IJBPermissions} from "@bananapus/core-v5/src/interfaces/IJBPermissions.sol";
+import {IJBTokens} from "@bananapus/core-v5/src/interfaces/IJBTokens.sol";
+import {JBConstants} from "@bananapus/core-v5/src/libraries/JBConstants.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {LibClone} from "solady/src/utils/LibClone.sol";
+
+import "../../src/JBCCIPSucker.sol";
+import "../../src/JBSucker.sol";
+import {JBCCIPSuckerDeployer} from "../../src/deployers/JBCCIPSuckerDeployer.sol";
+import {JBAddToBalanceMode} from "../../src/enums/JBAddToBalanceMode.sol";
+import {ICCIPRouter, IWrappedNativeToken} from "../../src/interfaces/ICCIPRouter.sol";
+import {JBInboxTreeRoot} from "../../src/structs/JBInboxTreeRoot.sol";
+import {JBMessageRoot} from "../../src/structs/JBMessageRoot.sol";
+import {JBRemoteToken} from "../../src/structs/JBRemoteToken.sol";
+import {JBTokenMapping} from "../../src/structs/JBTokenMapping.sol";
+import {MerkleLib} from "../../src/utils/MerkleLib.sol";
+
+/// @notice Minimal mock WETH for testing native token wrap/unwrap flows.
+contract MockWETH {
+    mapping(address => uint256) public balanceOf;
+
+    receive() external payable {}
+
+    function deposit() external payable {
+        balanceOf[msg.sender] += msg.value;
+    }
+
+    function withdraw(uint256 amount) external {
+        require(balanceOf[msg.sender] >= amount, "MockWETH: insufficient");
+        balanceOf[msg.sender] -= amount;
+        (bool ok,) = msg.sender.call{value: amount}("");
+        require(ok, "MockWETH: ETH transfer failed");
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function allowance(address, address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function totalSupply() external pure returns (uint256) {
+        return type(uint256).max;
+    }
+}
+
+/// @notice CCIP test sucker exposing internals for testing.
+contract CCIPTestSucker is JBCCIPSucker {
+    using MerkleLib for MerkleLib.Tree;
+
+    constructor(
+        JBCCIPSuckerDeployer deployer,
+        IJBDirectory directory,
+        IJBTokens tokens,
+        IJBPermissions permissions
+    ) JBCCIPSucker(deployer, directory, tokens, permissions, JBAddToBalanceMode.MANUAL, address(0)) {}
+
+    function exposed_validateTokenMapping(JBTokenMapping calldata map) external pure {
+        _validateTokenMapping(map);
+    }
+
+    function exposed_sendRootOverAMB(
+        uint256 transportPayment,
+        address token,
+        uint256 amount,
+        JBRemoteToken memory remoteToken,
+        JBMessageRoot memory message
+    ) external payable {
+        _sendRootOverAMB(transportPayment, 0, token, amount, remoteToken, message);
+    }
+
+    function exposed_insertIntoTree(
+        uint256 projectTokenCount,
+        address token,
+        uint256 terminalTokenAmount,
+        address beneficiary
+    ) external {
+        _insertIntoTree(projectTokenCount, token, terminalTokenAmount, beneficiary);
+    }
+
+    function test_setRemoteToken(address localToken, JBRemoteToken memory remoteToken) external {
+        _remoteTokenFor[localToken] = remoteToken;
+    }
+
+    function test_getInboxRoot(address token) external view returns (bytes32) {
+        return _inboxOf[token].root;
+    }
+
+    function test_getInboxNonce(address token) external view returns (uint64) {
+        return _inboxOf[token].nonce;
+    }
+
+    function test_getOutboxRoot(address token) external view returns (bytes32) {
+        return _outboxOf[token].tree.root();
+    }
+}
+
+/// @notice Base sucker exposing _validateTokenMapping for comparison testing.
+contract BaseTestSucker is JBSucker {
+    constructor(
+        IJBDirectory directory,
+        IJBPermissions permissions,
+        IJBTokens tokens
+    ) JBSucker(directory, permissions, tokens, JBAddToBalanceMode.MANUAL, address(0)) {}
+
+    function exposed_validateTokenMapping(JBTokenMapping calldata map) external pure {
+        _validateTokenMapping(map);
+    }
+
+    function _sendRootOverAMB(uint256, uint256, address, uint256, JBRemoteToken memory, JBMessageRoot memory)
+        internal
+        override
+    {}
+
+    function _isRemotePeer(address sender) internal view override returns (bool) {
+        return sender == address(this);
+    }
+
+    function peerChainId() external pure override returns (uint256) {
+        return 1;
+    }
+}
+
+/// @title CCIPNativeInteropTest
+/// @notice Tests for cross-chain native token interop between chains with different native tokens.
+///         Validates that the CCIP sucker correctly allows NATIVE_TOKEN -> ERC20 mappings
+///         (e.g., ETH mainnet <-> Celo where ETH is an ERC20 on Celo).
+contract CCIPNativeInteropTest is Test {
+    address constant MOCK_DEPLOYER = address(0xDE);
+    address constant MOCK_DIRECTORY = address(0xD1);
+    address constant MOCK_TOKENS = address(0xD2);
+    address constant MOCK_PERMISSIONS = address(0xD3);
+    address constant MOCK_ROUTER = address(0xD4);
+    address constant MOCK_PROJECTS = address(0xD5);
+
+    uint256 constant PROJECT_ID = 1;
+    uint256 constant REMOTE_CHAIN_ID = 42220; // Celo
+    uint64 constant REMOTE_CHAIN_SELECTOR = 1311226; // Celo CCIP selector
+
+    /// @notice Represents ETH as an ERC20 on Celo.
+    address celoETH = makeAddr("celoETH");
+
+    CCIPTestSucker ccipSucker;
+    BaseTestSucker baseSucker;
+    MockWETH mockWETH;
+
+    function setUp() public {
+        mockWETH = new MockWETH();
+
+        vm.label(MOCK_DEPLOYER, "MOCK_DEPLOYER");
+        vm.label(MOCK_DIRECTORY, "MOCK_DIRECTORY");
+        vm.label(MOCK_ROUTER, "MOCK_ROUTER");
+        vm.label(celoETH, "celoETH");
+
+        // Etch code at mock router so high-level Solidity calls pass extcodesize check.
+        vm.etch(MOCK_ROUTER, hex"01");
+
+        // Mock deployer responses for CCIP sucker constructor.
+        vm.mockCall(MOCK_DEPLOYER, abi.encodeWithSignature("ccipRemoteChainId()"), abi.encode(REMOTE_CHAIN_ID));
+        vm.mockCall(
+            MOCK_DEPLOYER, abi.encodeWithSignature("ccipRemoteChainSelector()"), abi.encode(REMOTE_CHAIN_SELECTOR)
+        );
+        vm.mockCall(MOCK_DEPLOYER, abi.encodeWithSignature("ccipRouter()"), abi.encode(MOCK_ROUTER));
+
+        // Mock CCIP router getWrappedNative.
+        vm.mockCall(MOCK_ROUTER, abi.encodeWithSignature("getWrappedNative()"), abi.encode(address(mockWETH)));
+
+        // Mock CCIP router getFee and ccipSend.
+        vm.mockCall(
+            MOCK_ROUTER, abi.encodeWithSelector(IRouterClient.getFee.selector), abi.encode(uint256(0.01 ether))
+        );
+        vm.mockCall(
+            MOCK_ROUTER, abi.encodeWithSelector(IRouterClient.ccipSend.selector), abi.encode(bytes32(uint256(1)))
+        );
+
+        // Mock directory.
+        vm.mockCall(MOCK_DIRECTORY, abi.encodeWithSignature("PROJECTS()"), abi.encode(MOCK_PROJECTS));
+        vm.mockCall(MOCK_PROJECTS, abi.encodeWithSignature("ownerOf(uint256)"), abi.encode(address(this)));
+
+        // Deploy CCIP singleton and clone.
+        CCIPTestSucker ccipSingleton = new CCIPTestSucker(
+            JBCCIPSuckerDeployer(MOCK_DEPLOYER),
+            IJBDirectory(MOCK_DIRECTORY),
+            IJBTokens(MOCK_TOKENS),
+            IJBPermissions(MOCK_PERMISSIONS)
+        );
+        ccipSucker = CCIPTestSucker(payable(LibClone.cloneDeterministic(address(ccipSingleton), bytes32("ccip"))));
+        ccipSucker.initialize(PROJECT_ID);
+
+        // Deploy base singleton and clone.
+        BaseTestSucker baseSingleton =
+            new BaseTestSucker(IJBDirectory(MOCK_DIRECTORY), IJBPermissions(MOCK_PERMISSIONS), IJBTokens(MOCK_TOKENS));
+        baseSucker = BaseTestSucker(payable(LibClone.cloneDeterministic(address(baseSingleton), bytes32("base"))));
+        baseSucker.initialize(PROJECT_ID);
+    }
+
+    // =========================================================================
+    // Test 1: CCIP sucker allows NATIVE_TOKEN -> ERC20 mapping
+    // =========================================================================
+
+    function test_mapToken_nativeToERC20_allowedOnCCIP() public view {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        // Should NOT revert — CCIP sucker allows native -> ERC20 for cross-chain interop.
+        ccipSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 2: Base sucker rejects NATIVE_TOKEN -> ERC20 mapping
+    // =========================================================================
+
+    function test_mapToken_nativeToERC20_rejectedOnBase() public {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_InvalidNativeRemoteAddress.selector, celoETH));
+        baseSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 3: NATIVE_TOKEN -> NATIVE_TOKEN allowed on both
+    // =========================================================================
+
+    function test_mapToken_nativeToNative_allowedOnBoth() public view {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: JBConstants.NATIVE_TOKEN,
+            minBridgeAmount: 0.01 ether
+        });
+
+        ccipSucker.exposed_validateTokenMapping(map);
+        baseSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 4: NATIVE_TOKEN -> address(0) disables on both
+    // =========================================================================
+
+    function test_mapToken_nativeToZero_disablesOnBoth() public view {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: address(0),
+            minBridgeAmount: 0
+        });
+
+        ccipSucker.exposed_validateTokenMapping(map);
+        baseSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 5: CCIP enforces minGas for native token mappings
+    // =========================================================================
+
+    function test_mapToken_minGas_enforced_forNative() public {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 100_000, // Below MESSENGER_ERC20_MIN_GAS_LIMIT (200_000)
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        // CCIP sucker requires minGas for ALL tokens since native wraps to WETH.
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_BelowMinGas.selector, 100_000, 200_000));
+        ccipSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 6: ccipReceive unwraps WETH when root.token == NATIVE_TOKEN
+    // =========================================================================
+
+    function test_ccipReceive_nativeToken_unwraps() public {
+        uint256 bridgeAmount = 1 ether;
+
+        // Give MockWETH ETH backing for the unwrap and credit WETH balance to the sucker.
+        vm.deal(address(mockWETH), bridgeAmount);
+        vm.store(
+            address(mockWETH),
+            keccak256(abi.encode(address(ccipSucker), uint256(0))), // balanceOf[sucker] at slot 0
+            bytes32(bridgeAmount)
+        );
+
+        uint256 ethBefore = address(ccipSucker).balance;
+
+        // Build CCIP message with NATIVE_TOKEN root.
+        JBMessageRoot memory msgRoot = JBMessageRoot({
+            token: JBConstants.NATIVE_TOKEN,
+            amount: bridgeAmount,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xdead))})
+        });
+
+        Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
+        tokenAmounts[0] = Client.EVMTokenAmount({token: address(mockWETH), amount: bridgeAmount});
+
+        Client.Any2EVMMessage memory message = Client.Any2EVMMessage({
+            messageId: bytes32(uint256(1)),
+            sourceChainSelector: REMOTE_CHAIN_SELECTOR,
+            sender: abi.encode(address(ccipSucker)), // peer is address(this)
+            data: abi.encode(msgRoot),
+            destTokenAmounts: tokenAmounts
+        });
+
+        vm.prank(MOCK_ROUTER);
+        ccipSucker.ccipReceive(message);
+
+        // Verify ETH was unwrapped.
+        assertEq(address(ccipSucker).balance, ethBefore + bridgeAmount, "ETH should be unwrapped from WETH");
+
+        // Verify inbox root was stored.
+        assertEq(ccipSucker.test_getInboxRoot(JBConstants.NATIVE_TOKEN), bytes32(uint256(0xdead)));
+        assertEq(ccipSucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN), 1);
+    }
+
+    // =========================================================================
+    // Test 7: ccipReceive does NOT unwrap for ERC20 tokens
+    // =========================================================================
+
+    function test_ccipReceive_erc20Token_noUnwrap() public {
+        uint256 bridgeAmount = 1 ether;
+
+        JBMessageRoot memory msgRoot = JBMessageRoot({
+            token: celoETH, // ERC20, not NATIVE_TOKEN
+            amount: bridgeAmount,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xbeef))})
+        });
+
+        Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
+        tokenAmounts[0] = Client.EVMTokenAmount({token: celoETH, amount: bridgeAmount});
+
+        Client.Any2EVMMessage memory message = Client.Any2EVMMessage({
+            messageId: bytes32(uint256(2)),
+            sourceChainSelector: REMOTE_CHAIN_SELECTOR,
+            sender: abi.encode(address(ccipSucker)),
+            data: abi.encode(msgRoot),
+            destTokenAmounts: tokenAmounts
+        });
+
+        uint256 ethBefore = address(ccipSucker).balance;
+
+        vm.prank(MOCK_ROUTER);
+        ccipSucker.ccipReceive(message);
+
+        // Verify NO unwrap — ETH balance unchanged.
+        assertEq(address(ccipSucker).balance, ethBefore, "ETH should NOT change for ERC20 token");
+
+        // Verify inbox root was stored for the ERC20 token.
+        assertEq(ccipSucker.test_getInboxRoot(celoETH), bytes32(uint256(0xbeef)));
+    }
+
+    // =========================================================================
+    // Test 8: _sendRootOverAMB wraps native token to WETH before CCIP send
+    // =========================================================================
+
+    function test_sendRoot_nativeToken_wrapsToWETH() public {
+        uint256 amount = 1 ether;
+        uint256 transport = 0.01 ether;
+
+        // Give the sucker ETH (simulating outbox balance).
+        vm.deal(address(ccipSucker), amount);
+
+        JBRemoteToken memory remoteToken = JBRemoteToken({
+            enabled: true,
+            emergencyHatch: false,
+            minGas: 200_000,
+            addr: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBMessageRoot memory msgRoot = JBMessageRoot({
+            token: celoETH,
+            amount: amount,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xdead))})
+        });
+
+        // Verify MockWETH balance is 0 before.
+        assertEq(mockWETH.balanceOf(address(ccipSucker)), 0);
+
+        // Send root — this should wrap native ETH to WETH.
+        ccipSucker.exposed_sendRootOverAMB{value: transport}(
+            transport, JBConstants.NATIVE_TOKEN, amount, remoteToken, msgRoot
+        );
+
+        // After wrapping: MockWETH received 1 ETH via deposit, sucker got 1 WETH.
+        // The mocked ccipSend doesn't actually transfer WETH, so sucker still has it.
+        assertEq(mockWETH.balanceOf(address(ccipSucker)), amount, "WETH should be minted from native deposit");
+
+        // MockWETH should hold the ETH backing.
+        assertEq(address(mockWETH).balance, amount, "MockWETH should hold the deposited ETH");
+    }
+
+    // =========================================================================
+    // Test 9: Full flow ETH mainnet -> Celo (native maps to ERC20)
+    // =========================================================================
+
+    function test_fullFlow_ethMainnet_to_celo() public {
+        // Step 1: Validate that NATIVE -> celoETH mapping is accepted on CCIP.
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+        ccipSucker.exposed_validateTokenMapping(map);
+
+        // Step 2: Set up the token mapping on the sucker.
+        ccipSucker.test_setRemoteToken(
+            JBConstants.NATIVE_TOKEN,
+            JBRemoteToken({enabled: true, emergencyHatch: false, minGas: 200_000, addr: celoETH, minBridgeAmount: 0.01 ether})
+        );
+
+        // Step 3: Insert a leaf into the outbox (simulating a user preparing to bridge).
+        ccipSucker.exposed_insertIntoTree({
+            projectTokenCount: 10 ether,
+            token: JBConstants.NATIVE_TOKEN,
+            terminalTokenAmount: 1 ether,
+            beneficiary: address(0x1234)
+        });
+
+        bytes32 outboxRoot = ccipSucker.test_getOutboxRoot(JBConstants.NATIVE_TOKEN);
+        assertTrue(outboxRoot != bytes32(0), "Outbox root should be non-zero");
+
+        // Step 4: Simulate receiving on the "Celo side" — the message arrives with
+        // root.token = celoETH (the ERC20 representation of ETH on Celo).
+        JBMessageRoot memory msgRoot = JBMessageRoot({
+            token: celoETH,
+            amount: 1 ether,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: outboxRoot})
+        });
+
+        Client.Any2EVMMessage memory message = Client.Any2EVMMessage({
+            messageId: bytes32(uint256(3)),
+            sourceChainSelector: REMOTE_CHAIN_SELECTOR,
+            sender: abi.encode(address(ccipSucker)),
+            data: abi.encode(msgRoot),
+            destTokenAmounts: new Client.EVMTokenAmount[](0)
+        });
+
+        vm.prank(MOCK_ROUTER);
+        ccipSucker.ccipReceive(message);
+
+        // Verify inbox stored correctly with celoETH as the token key.
+        assertEq(ccipSucker.test_getInboxRoot(celoETH), outboxRoot, "Inbox root should match outbox root");
+        assertEq(ccipSucker.test_getInboxNonce(celoETH), 1);
+    }
+
+    // =========================================================================
+    // Test 10: Full flow Celo -> ETH mainnet (receive triggers WETH unwrap)
+    // =========================================================================
+
+    function test_fullFlow_celo_to_ethMainnet() public {
+        uint256 bridgeAmount = 1 ether;
+
+        // Give MockWETH ETH backing and credit sucker's WETH balance.
+        vm.deal(address(mockWETH), bridgeAmount);
+        vm.store(
+            address(mockWETH),
+            keccak256(abi.encode(address(ccipSucker), uint256(0))),
+            bytes32(bridgeAmount)
+        );
+
+        // Simulate receiving on ETH mainnet — root.token = NATIVE_TOKEN because
+        // on mainnet, ETH is the native token. CCIP delivers WETH.
+        JBMessageRoot memory msgRoot = JBMessageRoot({
+            token: JBConstants.NATIVE_TOKEN,
+            amount: bridgeAmount,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xcafe))})
+        });
+
+        Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
+        tokenAmounts[0] = Client.EVMTokenAmount({token: address(mockWETH), amount: bridgeAmount});
+
+        Client.Any2EVMMessage memory message = Client.Any2EVMMessage({
+            messageId: bytes32(uint256(4)),
+            sourceChainSelector: REMOTE_CHAIN_SELECTOR,
+            sender: abi.encode(address(ccipSucker)),
+            data: abi.encode(msgRoot),
+            destTokenAmounts: tokenAmounts
+        });
+
+        uint256 ethBefore = address(ccipSucker).balance;
+
+        vm.prank(MOCK_ROUTER);
+        ccipSucker.ccipReceive(message);
+
+        // Verify unwrapping occurred.
+        assertEq(address(ccipSucker).balance, ethBefore + bridgeAmount, "Should unwrap WETH to ETH on receive");
+
+        // Verify inbox stored under NATIVE_TOKEN.
+        assertEq(ccipSucker.test_getInboxRoot(JBConstants.NATIVE_TOKEN), bytes32(uint256(0xcafe)));
+    }
+
+    // =========================================================================
+    // Test 11: ETH round-trip — NATIVE_TOKEN on mainnet <-> ERC20 on Celo
+    //
+    // This is THE critical cross-chain interop case:
+    //   ETH mainnet: ETH is NATIVE_TOKEN (address 0xEEE...EEE)
+    //   Celo:        ETH is an ERC-20 (e.g., 0x2DEf4285787d58a2f811AF24755A8150622f4361)
+    //
+    // The mapping: NATIVE_TOKEN -> celoETH (an ERC-20 address)
+    // Send path:   native ETH -> wrap to WETH -> CCIP bridges WETH -> Celo receives as ERC-20
+    // Return path: Celo sends ERC-20 ETH -> CCIP delivers as WETH -> unwrap WETH -> native ETH
+    // =========================================================================
+
+    function test_eth_roundTrip_nativeToERC20_and_back() public {
+        uint256 bridgeAmount = 2 ether;
+
+        // --- Outbound: ETH mainnet -> Celo (NATIVE_TOKEN -> celoETH ERC-20) ---
+
+        // 1. Validate the mapping is accepted.
+        JBTokenMapping memory outboundMap = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+        ccipSucker.exposed_validateTokenMapping(outboundMap);
+
+        // 2. Set the mapping and simulate outbox.
+        ccipSucker.test_setRemoteToken(
+            JBConstants.NATIVE_TOKEN,
+            JBRemoteToken({enabled: true, emergencyHatch: false, minGas: 200_000, addr: celoETH, minBridgeAmount: 0.01 ether})
+        );
+
+        // 3. Wrap native ETH -> WETH for CCIP transport.
+        vm.deal(address(ccipSucker), bridgeAmount);
+        assertEq(mockWETH.balanceOf(address(ccipSucker)), 0, "No WETH before send");
+
+        JBRemoteToken memory remoteToken = JBRemoteToken({
+            enabled: true, emergencyHatch: false, minGas: 200_000, addr: celoETH, minBridgeAmount: 0.01 ether
+        });
+        JBMessageRoot memory sendMsg = JBMessageRoot({
+            token: celoETH,
+            amount: bridgeAmount,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xaaa))})
+        });
+        ccipSucker.exposed_sendRootOverAMB{value: 0.01 ether}(
+            0.01 ether, JBConstants.NATIVE_TOKEN, bridgeAmount, remoteToken, sendMsg
+        );
+
+        // Verify native ETH was wrapped to WETH.
+        assertEq(mockWETH.balanceOf(address(ccipSucker)), bridgeAmount, "ETH should be wrapped to WETH for CCIP send");
+        assertEq(address(mockWETH).balance, bridgeAmount, "MockWETH holds the ETH backing");
+
+        // --- Return: Celo -> ETH mainnet (celoETH ERC-20 -> NATIVE_TOKEN) ---
+
+        // 4. Simulate CCIP delivering WETH back (router unwrap path).
+        //    On mainnet, root.token = NATIVE_TOKEN, so ccipReceive unwraps WETH -> ETH.
+        vm.deal(address(mockWETH), bridgeAmount);
+        vm.store(
+            address(mockWETH),
+            keccak256(abi.encode(address(ccipSucker), uint256(0))),
+            bytes32(bridgeAmount)
+        );
+
+        uint256 ethBefore = address(ccipSucker).balance;
+
+        JBMessageRoot memory recvMsg = JBMessageRoot({
+            token: JBConstants.NATIVE_TOKEN,
+            amount: bridgeAmount,
+            remoteRoot: JBInboxTreeRoot({nonce: 2, root: bytes32(uint256(0xbbb))})
+        });
+
+        Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
+        tokenAmounts[0] = Client.EVMTokenAmount({token: address(mockWETH), amount: bridgeAmount});
+
+        Client.Any2EVMMessage memory ccipMsg = Client.Any2EVMMessage({
+            messageId: bytes32(uint256(99)),
+            sourceChainSelector: REMOTE_CHAIN_SELECTOR,
+            sender: abi.encode(address(ccipSucker)),
+            data: abi.encode(recvMsg),
+            destTokenAmounts: tokenAmounts
+        });
+
+        vm.prank(MOCK_ROUTER);
+        ccipSucker.ccipReceive(ccipMsg);
+
+        // 5. Verify WETH was unwrapped back to native ETH.
+        assertEq(
+            address(ccipSucker).balance,
+            ethBefore + bridgeAmount,
+            "Return path: WETH should be unwrapped back to native ETH"
+        );
+
+        // Verify inbox roots for both directions.
+        assertEq(ccipSucker.test_getInboxRoot(JBConstants.NATIVE_TOKEN), bytes32(uint256(0xbbb)));
+        assertEq(ccipSucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN), 2);
+    }
+
+    // =========================================================================
+    // Test 12: ERC20 -> ERC20 mapping works on both suckers
+    // =========================================================================
+
+    function test_mapToken_erc20ToERC20_allowedOnBoth() public view {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48), // USDC-like
+            minGas: 200_000,
+            remoteToken: address(0xef4229c8c3250C675F21BCefa42f58EfbfF6002a), // celoUSDC-like
+            minBridgeAmount: 1e6
+        });
+
+        ccipSucker.exposed_validateTokenMapping(map);
+        baseSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 12: Both suckers enforce minGas for ERC20 tokens
+    // =========================================================================
+
+    function test_mapToken_minGas_enforced_forERC20() public {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: makeAddr("USDC"),
+            minGas: 50_000, // Below MESSENGER_ERC20_MIN_GAS_LIMIT (200_000)
+            remoteToken: makeAddr("celoUSDC"),
+            minBridgeAmount: 1e6
+        });
+
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_BelowMinGas.selector, 50_000, 200_000));
+        ccipSucker.exposed_validateTokenMapping(map);
+
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_BelowMinGas.selector, 50_000, 200_000));
+        baseSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 13: Base sucker skips minGas for native (no wrapping on OP/Arb)
+    // =========================================================================
+
+    function test_mapToken_base_skipsMinGas_forNative() public view {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 0, // Zero minGas
+            remoteToken: JBConstants.NATIVE_TOKEN,
+            minBridgeAmount: 0.01 ether
+        });
+
+        // Base sucker skips minGas for native tokens (OP/Arb bridge natively).
+        baseSucker.exposed_validateTokenMapping(map);
+    }
+
+    // =========================================================================
+    // Test 14: CCIP enforces minGas even for native-to-native
+    // =========================================================================
+
+    function test_mapToken_ccip_enforcesMinGas_forNativeToNative() public {
+        JBTokenMapping memory map = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 0, // Zero minGas
+            remoteToken: JBConstants.NATIVE_TOKEN,
+            minBridgeAmount: 0.01 ether
+        });
+
+        // CCIP sucker wraps native to WETH, so needs gas for ERC20 transfer even for native-to-native.
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_BelowMinGas.selector, 0, 200_000));
+        ccipSucker.exposed_validateTokenMapping(map);
+    }
+
+    receive() external payable {}
+}

--- a/test/unit/deployer.t.sol
+++ b/test/unit/deployer.t.sol
@@ -306,8 +306,8 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
     }
 
     function testArbDeployer(bool _layer, IInbox _inbox, IArbGatewayRouter _gatewayRouter) public {
-        // One of these has to be set in order for it to be a 'valid' configuration.
-        vm.assume(_inbox != IInbox(address(0)) || _gatewayRouter != IArbGatewayRouter(address(0)));
+        // All of these must be set for a valid configuration.
+        vm.assume(_inbox != IInbox(address(0)) && _gatewayRouter != IArbGatewayRouter(address(0)));
 
         IJBSuckerDeployer deployer = _setupArbitrumDeployer(_layer ? JBLayer.L1 : JBLayer.L2, _inbox, _gatewayRouter);
         IJBSucker sucker = _deployDirectly(deployer, projectId, bytes32(0));
@@ -316,8 +316,8 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
     }
 
     function testArbDeployerThroughRegistry(bool _layer, IInbox _inbox, IArbGatewayRouter _gatewayRouter) public {
-        // One of these has to be set in order for it to be a 'valid' configuration.
-        vm.assume(_inbox != IInbox(address(0)) || _gatewayRouter != IArbGatewayRouter(address(0)));
+        // All of these must be set for a valid configuration.
+        vm.assume(_inbox != IInbox(address(0)) && _gatewayRouter != IArbGatewayRouter(address(0)));
 
         _allowMapping(projectId, address(registry));
         IJBSuckerDeployer deployer =

--- a/test/unit/multi_chain_evolution.t.sol
+++ b/test/unit/multi_chain_evolution.t.sol
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import /* {*} from */ "@bananapus/core-v5/test/helpers/TestBaseWorkflow.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
+import {IJBController} from "@bananapus/core-v5/src/interfaces/IJBController.sol";
+import {IJBSucker} from "../../src/interfaces/IJBSucker.sol";
+import {IJBSuckerDeployer} from "../../src/interfaces/IJBSuckerDeployer.sol";
+
+import "../../src/JBSucker.sol";
+import "../../src/JBOptimismSucker.sol";
+import "../../src/JBCCIPSucker.sol";
+import "../../src/deployers/JBOptimismSuckerDeployer.sol";
+import "../../src/deployers/JBCCIPSuckerDeployer.sol";
+import {JBSuckerRegistry} from "../../src/JBSuckerRegistry.sol";
+import {JBSuckerDeployerConfig} from "../../src/structs/JBSuckerDeployerConfig.sol";
+import {JBSuckersPair} from "../../src/structs/JBSuckersPair.sol";
+import {JBSuckerState} from "../../src/enums/JBSuckerState.sol";
+import {JBTokenMapping} from "../../src/structs/JBTokenMapping.sol";
+import {JBRemoteToken} from "../../src/structs/JBRemoteToken.sol";
+
+/// @title MultiChainEvolutionTest
+/// @notice Tests that a project can start on one chain and incrementally expand to new chains over time.
+///
+/// Lifecycle story:
+///   Phase 1: Project launches on Ethereum mainnet (no cross-chain).
+///   Phase 2: Expand to Optimism — deploy OP sucker, map ETH (NATIVE_TOKEN -> NATIVE_TOKEN).
+///   Phase 3: Add USDC bridging to Optimism — map USDC on the existing OP sucker.
+///   Phase 4: Expand to Celo via CCIP — deploy CCIP sucker, map ETH as NATIVE_TOKEN -> celoETH (ERC-20).
+///   Phase 5: Add USDC bridging to Celo — map USDC -> celoUSDC on the existing CCIP sucker.
+///   Phase 6: Deprecate the OP sucker — Celo sucker continues working.
+contract MultiChainEvolutionTest is Test, TestBaseWorkflow, IERC721Receiver {
+    JBSuckerRegistry registry;
+    uint256 projectId;
+
+    // Mock bridge/messenger addresses for OP.
+    IOPMessenger constant MOCK_OP_MESSENGER = IOPMessenger(address(0xA001));
+    IOPStandardBridge constant MOCK_OP_BRIDGE = IOPStandardBridge(address(0xA002));
+
+    // Mock CCIP router.
+    address constant MOCK_CCIP_ROUTER_ADDR = address(0xA003);
+
+    // Celo chain constants.
+    uint256 constant CELO_CHAIN_ID = 42220;
+    uint64 constant CELO_CHAIN_SELECTOR = 1311226;
+
+    // Token addresses representing tokens on remote chains.
+    // On Celo, ETH is an ERC-20 (not native).
+    address celoETH = address(0xCE10E001);
+    // USDC addresses (local and remote).
+    address localUSDC = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    address opUSDC = address(0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85);
+    address celoUSDC = address(0xef4229c8c3250C675F21BCefa42f58EfbfF6002a);
+
+    // Deployers (set in setUp).
+    JBOptimismSuckerDeployer opDeployer;
+    JBCCIPSuckerDeployer ccipDeployer;
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.label(address(MOCK_OP_MESSENGER), "OP_MESSENGER");
+        vm.label(address(MOCK_OP_BRIDGE), "OP_BRIDGE");
+        vm.label(MOCK_CCIP_ROUTER_ADDR, "CCIP_ROUTER");
+
+        // Etch code at mock addresses so Solidity's extcodesize checks pass.
+        vm.etch(address(MOCK_OP_MESSENGER), hex"01");
+        vm.etch(address(MOCK_OP_BRIDGE), hex"01");
+        vm.etch(MOCK_CCIP_ROUTER_ADDR, hex"01");
+
+        // Deploy the registry.
+        registry = new JBSuckerRegistry(jbDirectory(), jbPermissions(), address(this), address(0));
+
+        // --- Set up OP deployer ---
+        opDeployer = new JBOptimismSuckerDeployer({
+            directory: jbDirectory(),
+            permissions: jbPermissions(),
+            tokens: jbTokens(),
+            configurator: address(this),
+            trusted_forwarder: address(0)
+        });
+        opDeployer.setChainSpecificConstants(MOCK_OP_MESSENGER, MOCK_OP_BRIDGE);
+
+        JBOptimismSucker opSingleton = new JBOptimismSucker({
+            deployer: opDeployer,
+            directory: jbDirectory(),
+            permissions: jbPermissions(),
+            tokens: jbTokens(),
+            addToBalanceMode: JBAddToBalanceMode.MANUAL,
+            trusted_forwarder: address(0)
+        });
+        opDeployer.configureSingleton(opSingleton);
+
+        // --- Set up CCIP deployer ---
+        ccipDeployer = new JBCCIPSuckerDeployer({
+            directory: jbDirectory(),
+            permissions: jbPermissions(),
+            tokens: jbTokens(),
+            configurator: address(this),
+            trusted_forwarder: address(0)
+        });
+        ccipDeployer.setChainSpecificConstants({
+            remoteChainId: CELO_CHAIN_ID,
+            remoteChainSelector: CELO_CHAIN_SELECTOR,
+            router: ICCIPRouter(MOCK_CCIP_ROUTER_ADDR)
+        });
+
+        JBCCIPSucker ccipSingleton = new JBCCIPSucker({
+            deployer: ccipDeployer,
+            directory: jbDirectory(),
+            permissions: jbPermissions(),
+            tokens: jbTokens(),
+            addToBalanceMode: JBAddToBalanceMode.MANUAL,
+            trusted_forwarder: address(0)
+        });
+        ccipDeployer.configureSingleton(ccipSingleton);
+
+        // Allow both deployers in the registry.
+        registry.allowSuckerDeployer(address(opDeployer));
+        registry.allowSuckerDeployer(address(ccipDeployer));
+
+        // --- Launch project ---
+        JBRulesetMetadata memory metadata = JBRulesetMetadata({
+            reservedPercent: 0,
+            cashOutTaxRate: 0,
+            baseCurrency: uint32(uint160(JBConstants.NATIVE_TOKEN)),
+            pausePay: false,
+            pauseCreditTransfers: false,
+            allowOwnerMinting: true,
+            allowSetCustomToken: false,
+            allowTerminalMigration: false,
+            allowSetTerminals: false,
+            allowSetController: false,
+            allowAddAccountingContext: true,
+            allowAddPriceFeed: true,
+            ownerMustSendPayouts: false,
+            holdFees: false,
+            useTotalSurplusForCashOuts: true,
+            useDataHookForPay: false,
+            useDataHookForCashOut: false,
+            dataHook: address(0),
+            metadata: 0
+        });
+
+        JBRulesetConfig[] memory rulesetConfigs = new JBRulesetConfig[](1);
+        rulesetConfigs[0].mustStartAtOrAfter = 0;
+        rulesetConfigs[0].duration = 0;
+        rulesetConfigs[0].weight = 1000 * 10 ** 18;
+        rulesetConfigs[0].weightCutPercent = 0;
+        rulesetConfigs[0].approvalHook = IJBRulesetApprovalHook(address(0));
+        rulesetConfigs[0].metadata = metadata;
+        rulesetConfigs[0].splitGroups = new JBSplitGroup[](0);
+        rulesetConfigs[0].fundAccessLimitGroups = new JBFundAccessLimitGroup[](0);
+
+        JBAccountingContext[] memory tokensToAccept = new JBAccountingContext[](1);
+        tokensToAccept[0] = JBAccountingContext({
+            token: JBConstants.NATIVE_TOKEN,
+            decimals: 18,
+            currency: uint32(uint160(JBConstants.NATIVE_TOKEN))
+        });
+
+        JBTerminalConfig[] memory terminalConfigs = new JBTerminalConfig[](1);
+        terminalConfigs[0] =
+            JBTerminalConfig({terminal: jbMultiTerminal(), accountingContextsToAccept: tokensToAccept});
+
+        projectId = jbController().launchProjectFor({
+            owner: address(this),
+            projectUri: "myproject",
+            rulesetConfigurations: rulesetConfigs,
+            terminalConfigurations: terminalConfigs,
+            memo: ""
+        });
+    }
+
+    // =========================================================================
+    // Full lifecycle: project starts on one chain, evolves to many
+    // =========================================================================
+
+    // Storage vars for lifecycle test (avoids stack-too-deep).
+    IJBSucker _opSucker;
+    IJBSucker _celoSucker;
+
+    function test_lifecycle_projectExpandsAcrossChainsOverTime() public {
+        // ---------------------------------------------------------------
+        // Phase 1: Project exists only on Ethereum mainnet.
+        //          No suckers deployed yet.
+        // ---------------------------------------------------------------
+
+        assertEq(registry.suckersOf(projectId).length, 0, "Phase 1: no suckers yet");
+
+        // Grant the registry MAP_SUCKER_TOKEN permission so deploySuckersFor can call mapTokens.
+        _grantMapPermission(address(registry));
+
+        // ---------------------------------------------------------------
+        // Phase 2: Expand to Optimism.
+        //          Deploy OP sucker. Map NATIVE_TOKEN -> NATIVE_TOKEN
+        //          (both chains have ETH as native).
+        // ---------------------------------------------------------------
+        {
+            JBTokenMapping[] memory opMappings = new JBTokenMapping[](1);
+            opMappings[0] = JBTokenMapping({
+                localToken: JBConstants.NATIVE_TOKEN,
+                minGas: 200_000,
+                remoteToken: JBConstants.NATIVE_TOKEN,
+                minBridgeAmount: 0.01 ether
+            });
+
+            JBSuckerDeployerConfig[] memory opConfig = new JBSuckerDeployerConfig[](1);
+            opConfig[0] =
+                JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(opDeployer)), mappings: opMappings});
+
+            _opSucker = IJBSucker(registry.deploySuckersFor(projectId, bytes32("op_salt"), opConfig)[0]);
+        }
+
+        assertEq(registry.suckersOf(projectId).length, 1, "Phase 2: one sucker (OP)");
+        assertTrue(registry.isSuckerOf(projectId, address(_opSucker)), "Phase 2: OP sucker registered");
+
+        JBRemoteToken memory opNative = _opSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN);
+        assertTrue(opNative.enabled, "Phase 2: native mapping enabled on OP");
+        assertEq(opNative.addr, JBConstants.NATIVE_TOKEN, "Phase 2: native maps to native on OP");
+
+        // ---------------------------------------------------------------
+        // Phase 3: Add USDC bridging to Optimism.
+        //          Call mapToken on the existing OP sucker.
+        // ---------------------------------------------------------------
+
+        _opSucker.mapToken(
+            JBTokenMapping({localToken: localUSDC, minGas: 200_000, remoteToken: opUSDC, minBridgeAmount: 1e6})
+        );
+
+        assertTrue(_opSucker.remoteTokenFor(localUSDC).enabled, "Phase 3: USDC enabled on OP");
+        assertEq(_opSucker.remoteTokenFor(localUSDC).addr, opUSDC, "Phase 3: USDC maps to opUSDC");
+        assertTrue(_opSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).enabled, "Phase 3: native still works");
+
+        // ---------------------------------------------------------------
+        // Phase 4: Expand to Celo via CCIP.
+        //          Deploy CCIP sucker. Map NATIVE_TOKEN -> celoETH (ERC-20).
+        //
+        //          THIS IS THE KEY CROSS-CHAIN NATIVE TOKEN INTEROP CASE:
+        //          On Ethereum, ETH is the native token (NATIVE_TOKEN).
+        //          On Celo, ETH is an ERC-20 (celoETH address).
+        //          The CCIP sucker allows this mapping because it wraps
+        //          native ETH -> WETH for CCIP transport, and the receiving
+        //          side processes celoETH as an ERC-20 (no unwrap).
+        // ---------------------------------------------------------------
+        {
+            JBTokenMapping[] memory celoMappings = new JBTokenMapping[](1);
+            celoMappings[0] = JBTokenMapping({
+                localToken: JBConstants.NATIVE_TOKEN,
+                minGas: 200_000,
+                remoteToken: celoETH, // ERC-20 on Celo, NOT NATIVE_TOKEN
+                minBridgeAmount: 0.01 ether
+            });
+
+            JBSuckerDeployerConfig[] memory celoConfig = new JBSuckerDeployerConfig[](1);
+            celoConfig[0] =
+                JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(ccipDeployer)), mappings: celoMappings});
+
+            _celoSucker = IJBSucker(registry.deploySuckersFor(projectId, bytes32("celo_salt"), celoConfig)[0]);
+        }
+
+        assertEq(registry.suckersOf(projectId).length, 2, "Phase 4: two suckers (OP + Celo)");
+        assertTrue(registry.isSuckerOf(projectId, address(_celoSucker)), "Phase 4: Celo sucker registered");
+        assertTrue(registry.isSuckerOf(projectId, address(_opSucker)), "Phase 4: OP sucker still registered");
+
+        JBRemoteToken memory celoNative = _celoSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN);
+        assertTrue(celoNative.enabled, "Phase 4: native mapping enabled on Celo");
+        assertEq(celoNative.addr, celoETH, "Phase 4: native maps to celoETH (ERC-20) on Celo");
+        assertEq(registry.suckerPairsOf(projectId).length, 2, "Phase 4: two sucker pairs");
+
+        // ---------------------------------------------------------------
+        // Phase 5: Add USDC bridging to Celo.
+        //          Call mapToken on the existing CCIP sucker.
+        // ---------------------------------------------------------------
+
+        _celoSucker.mapToken(
+            JBTokenMapping({localToken: localUSDC, minGas: 200_000, remoteToken: celoUSDC, minBridgeAmount: 1e6})
+        );
+
+        assertTrue(_celoSucker.remoteTokenFor(localUSDC).enabled, "Phase 5: USDC enabled on Celo");
+        assertEq(_celoSucker.remoteTokenFor(localUSDC).addr, celoUSDC, "Phase 5: USDC maps to celoUSDC");
+
+        // OP sucker is completely independent — its mappings unchanged.
+        assertEq(
+            _opSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).addr,
+            JBConstants.NATIVE_TOKEN,
+            "Phase 5: OP native mapping unchanged"
+        );
+        assertEq(_opSucker.remoteTokenFor(localUSDC).addr, opUSDC, "Phase 5: OP USDC mapping unchanged");
+
+        // ---------------------------------------------------------------
+        // Phase 6: Deprecate the OP sucker.
+        //          The Celo sucker continues working.
+        // ---------------------------------------------------------------
+
+        uint40 deprecationTime = uint40(block.timestamp + 14 days);
+        JBOptimismSucker(payable(address(_opSucker))).setDeprecation(deprecationTime);
+        vm.warp(deprecationTime);
+
+        assertEq(uint8(_opSucker.state()), uint8(JBSuckerState.DEPRECATED), "Phase 6: OP sucker deprecated");
+
+        registry.removeDeprecatedSucker(projectId, address(_opSucker));
+        assertEq(registry.suckersOf(projectId).length, 1, "Phase 6: only Celo sucker remains");
+
+        assertEq(uint8(_celoSucker.state()), uint8(JBSuckerState.ENABLED), "Phase 6: Celo still enabled");
+        assertTrue(
+            _celoSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).enabled,
+            "Phase 6: Celo native mapping still works"
+        );
+        assertEq(
+            _celoSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).addr,
+            celoETH,
+            "Phase 6: Celo native still maps to celoETH"
+        );
+    }
+
+    // =========================================================================
+    // Focused: deploy suckers to multiple chains in one transaction
+    // =========================================================================
+
+    function test_canDeployToMultipleChainsAtOnce() public {
+        _grantMapPermission(address(registry));
+
+        // Deploy to both OP and Celo in a single deploySuckersFor call.
+        JBSuckerDeployerConfig[] memory configs = new JBSuckerDeployerConfig[](2);
+
+        JBTokenMapping[] memory opMappings = new JBTokenMapping[](1);
+        opMappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: JBConstants.NATIVE_TOKEN,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBTokenMapping[] memory celoMappings = new JBTokenMapping[](1);
+        celoMappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        configs[0] = JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(opDeployer)), mappings: opMappings});
+        configs[1] =
+            JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(ccipDeployer)), mappings: celoMappings});
+
+        address[] memory suckers = registry.deploySuckersFor(projectId, bytes32("both"), configs);
+
+        assertEq(suckers.length, 2, "Should deploy 2 suckers");
+        assertEq(registry.suckersOf(projectId).length, 2, "Registry should track 2 suckers");
+
+        // Verify each sucker has its own independent mapping.
+        IJBSucker opSucker = IJBSucker(suckers[0]);
+        IJBSucker celoSucker = IJBSucker(suckers[1]);
+
+        assertEq(
+            opSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).addr,
+            JBConstants.NATIVE_TOKEN,
+            "OP: native -> native"
+        );
+        assertEq(
+            celoSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).addr,
+            celoETH,
+            "Celo: native -> celoETH (ERC-20)"
+        );
+    }
+
+    // =========================================================================
+    // Focused: add tokens incrementally to an existing sucker
+    // =========================================================================
+
+    function test_canMapTokensIncrementallyToExistingSucker() public {
+        _grantMapPermission(address(registry));
+
+        // Deploy CCIP sucker with just native mapping.
+        JBTokenMapping[] memory initialMappings = new JBTokenMapping[](1);
+        initialMappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBSuckerDeployerConfig[] memory config = new JBSuckerDeployerConfig[](1);
+        config[0] =
+            JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(ccipDeployer)), mappings: initialMappings});
+
+        address[] memory suckers = registry.deploySuckersFor(projectId, bytes32("incr"), config);
+        IJBSucker sucker = IJBSucker(suckers[0]);
+
+        // Initially: only native mapped.
+        assertTrue(sucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).enabled, "Native should be mapped");
+        assertFalse(sucker.remoteTokenFor(localUSDC).enabled, "USDC should NOT be mapped yet");
+
+        // Later: project owner adds USDC.
+        sucker.mapToken(
+            JBTokenMapping({localToken: localUSDC, minGas: 200_000, remoteToken: celoUSDC, minBridgeAmount: 1e6})
+        );
+
+        // Now both are mapped.
+        assertTrue(sucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).enabled, "Native still mapped");
+        assertTrue(sucker.remoteTokenFor(localUSDC).enabled, "USDC now mapped");
+        assertEq(sucker.remoteTokenFor(localUSDC).addr, celoUSDC, "USDC maps to celoUSDC");
+    }
+
+    // =========================================================================
+    // Focused: modifications to one sucker don't affect another
+    // =========================================================================
+
+    function test_suckerMappingsAreIndependent() public {
+        _grantMapPermission(address(registry));
+
+        // Deploy two suckers.
+        JBTokenMapping[] memory nativeMappings = new JBTokenMapping[](1);
+        nativeMappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: JBConstants.NATIVE_TOKEN,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBSuckerDeployerConfig[] memory opConfig = new JBSuckerDeployerConfig[](1);
+        opConfig[0] =
+            JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(opDeployer)), mappings: nativeMappings});
+
+        JBTokenMapping[] memory celoNativeMappings = new JBTokenMapping[](1);
+        celoNativeMappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBSuckerDeployerConfig[] memory celoConfig = new JBSuckerDeployerConfig[](1);
+        celoConfig[0] =
+            JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(ccipDeployer)), mappings: celoNativeMappings});
+
+        address[] memory opSuckers = registry.deploySuckersFor(projectId, bytes32("ind_op"), opConfig);
+        address[] memory celoSuckers = registry.deploySuckersFor(projectId, bytes32("ind_celo"), celoConfig);
+
+        IJBSucker opSucker = IJBSucker(opSuckers[0]);
+        IJBSucker celoSucker = IJBSucker(celoSuckers[0]);
+
+        // Map USDC only on the Celo sucker.
+        celoSucker.mapToken(
+            JBTokenMapping({localToken: localUSDC, minGas: 200_000, remoteToken: celoUSDC, minBridgeAmount: 1e6})
+        );
+
+        // OP sucker should NOT have USDC mapped.
+        assertFalse(opSucker.remoteTokenFor(localUSDC).enabled, "OP sucker should NOT have USDC");
+
+        // Celo sucker should have USDC mapped.
+        assertTrue(celoSucker.remoteTokenFor(localUSDC).enabled, "Celo sucker should have USDC");
+
+        // Disable native on OP sucker.
+        opSucker.mapToken(
+            JBTokenMapping({localToken: JBConstants.NATIVE_TOKEN, minGas: 200_000, remoteToken: address(0), minBridgeAmount: 0})
+        );
+
+        // OP native disabled, Celo native unaffected.
+        assertFalse(opSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).enabled, "OP native disabled");
+        assertTrue(celoSucker.remoteTokenFor(JBConstants.NATIVE_TOKEN).enabled, "Celo native still enabled");
+    }
+
+    // =========================================================================
+    // Focused: CCIP sucker accepts NATIVE -> ERC20, OP sucker rejects it
+    // =========================================================================
+
+    function test_nativeToERC20_acceptedOnCCIP_rejectedOnOP() public {
+        _grantMapPermission(address(registry));
+
+        // Deploy both suckers with just a placeholder native->native mapping.
+        JBTokenMapping[] memory nativeMappings = new JBTokenMapping[](1);
+        nativeMappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: JBConstants.NATIVE_TOKEN,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBSuckerDeployerConfig[] memory opConfig = new JBSuckerDeployerConfig[](1);
+        opConfig[0] =
+            JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(opDeployer)), mappings: nativeMappings});
+        address[] memory opSuckers = registry.deploySuckersFor(projectId, bytes32("natv_op"), opConfig);
+
+        // CCIP sucker: deploy with NATIVE -> celoETH (ERC-20). Should succeed.
+        JBTokenMapping[] memory celoEthMappings = new JBTokenMapping[](1);
+        celoEthMappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: celoETH,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBSuckerDeployerConfig[] memory celoConfig = new JBSuckerDeployerConfig[](1);
+        celoConfig[0] =
+            JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(ccipDeployer)), mappings: celoEthMappings});
+
+        // This should succeed — CCIP allows NATIVE -> ERC-20.
+        address[] memory celoSuckers = registry.deploySuckersFor(projectId, bytes32("natv_celo"), celoConfig);
+        assertEq(
+            IJBSucker(celoSuckers[0]).remoteTokenFor(JBConstants.NATIVE_TOKEN).addr,
+            celoETH,
+            "CCIP: NATIVE -> celoETH accepted"
+        );
+
+        // OP sucker: try to map NATIVE -> celoETH (ERC-20). Should REVERT.
+        vm.expectRevert(
+            abi.encodeWithSelector(JBSucker.JBSucker_InvalidNativeRemoteAddress.selector, celoETH)
+        );
+        IJBSucker(opSuckers[0]).mapToken(
+            JBTokenMapping({localToken: JBConstants.NATIVE_TOKEN, minGas: 200_000, remoteToken: celoETH, minBridgeAmount: 0.01 ether})
+        );
+    }
+
+    // =========================================================================
+    // Focused: can replace a deprecated sucker with a new one
+    // =========================================================================
+
+    function test_canReplaceSuckerAfterDeprecation() public {
+        _grantMapPermission(address(registry));
+
+        // Deploy initial OP sucker.
+        JBTokenMapping[] memory mappings = new JBTokenMapping[](1);
+        mappings[0] = JBTokenMapping({
+            localToken: JBConstants.NATIVE_TOKEN,
+            minGas: 200_000,
+            remoteToken: JBConstants.NATIVE_TOKEN,
+            minBridgeAmount: 0.01 ether
+        });
+
+        JBSuckerDeployerConfig[] memory config = new JBSuckerDeployerConfig[](1);
+        config[0] = JBSuckerDeployerConfig({deployer: IJBSuckerDeployer(address(opDeployer)), mappings: mappings});
+
+        address[] memory firstDeploy = registry.deploySuckersFor(projectId, bytes32("v1"), config);
+        address oldSucker = firstDeploy[0];
+        assertEq(registry.suckersOf(projectId).length, 1);
+
+        // Deprecate it.
+        uint40 deprecationTime = uint40(block.timestamp + 14 days);
+        JBOptimismSucker(payable(oldSucker)).setDeprecation(deprecationTime);
+        vm.warp(deprecationTime);
+        assertEq(uint8(IJBSucker(oldSucker).state()), uint8(JBSuckerState.DEPRECATED));
+
+        // Remove from registry.
+        registry.removeDeprecatedSucker(projectId, oldSucker);
+        assertEq(registry.suckersOf(projectId).length, 0, "Old sucker removed");
+
+        // Deploy a replacement sucker with a new salt.
+        address[] memory secondDeploy = registry.deploySuckersFor(projectId, bytes32("v2"), config);
+        address newSucker = secondDeploy[0];
+
+        assertEq(registry.suckersOf(projectId).length, 1, "New sucker deployed");
+        assertTrue(registry.isSuckerOf(projectId, newSucker), "New sucker registered");
+        assertFalse(registry.isSuckerOf(projectId, oldSucker), "Old sucker no longer registered");
+        assertTrue(newSucker != oldSucker, "New sucker has different address");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    function _grantMapPermission(address operator) internal {
+        uint8[] memory permissions = new uint8[](1);
+        permissions[0] = JBPermissionIds.MAP_SUCKER_TOKEN;
+
+        jbPermissions().setPermissionsFor(
+            address(this),
+            JBPermissionsData({operator: operator, projectId: uint56(projectId), permissionIds: permissions})
+        );
+    }
+
+    function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
- Change deployer _layerSpecificConfigurationIsSet from || to && so partial configuration is rejected
- Remove arbLayer from the check since JBLayer.L1 == 0 (same as default) and all fields are set atomically in setChainSpecificConstants
- Restore native token mapping constraint in JBCCIPSucker to prevent mapping native token to arbitrary remote addresses

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: