### PR TITLE
fix: align IJBSucker.prepare argument name with implementation

### DIFF
--- a/src/interfaces/IJBSucker.sol
+++ b/src/interfaces/IJBSucker.sol
@@ -64,7 +64,7 @@ interface IJBSucker is IERC165 {
     function mapToken(JBTokenMapping calldata map) external payable;
     function mapTokens(JBTokenMapping[] calldata maps) external payable;
     function prepare(
-        uint256 projectTokenAmount,
+        uint256 projectTokenCount,
         address beneficiary,
         uint256 minTokensReclaimed,
         address token


### PR DESCRIPTION
Renames projectTokenAmount to projectTokenCount to match JBSucker.sol.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: