### PR TITLE
Add Celo mainnet CCIP sucker support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,8 @@ ethereum_sepolia ="${RPC_ETHEREUM_SEPOLIA}"
 optimism_sepolia = "${RPC_OPTIMISM_SEPOLIA}"
 polygon_mumbai = "${RPC_POLYGON_MUMBAI}"
 base_sepolia = "${RPC_BASE_SEPOLIA}"
+celo = "${RPC_CELO_MAINNET}"
+celo_sepolia = "${RPC_CELO_SEPOLIA}"
 
 [profile.ci_sizes]
 optimizer_runs = 200

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -31,14 +31,18 @@ contract DeployScript is Script, Sphinx {
     bytes32 ARB_BASE_SALT = "_SUCKER_ARB_BASE_";
     bytes32 ARB_OP_SALT = "_SUCKER_ARB_OP_";
     bytes32 OP_BASE_SALT = "_SUCKER_OP_BASE_";
+    bytes32 CELO_SALT = "_SUCKER_ETH_CELO_";
+    bytes32 ARB_CELO_SALT = "_SUCKER_ARB_CELO_";
+    bytes32 OP_CELO_SALT = "_SUCKER_OP_CELO_";
+    bytes32 BASE_CELO_SALT = "_SUCKER_BASE_CELO";
 
     bytes32 REGISTRY_SALT = "REGISTRY";
 
     function configureSphinx() public override {
         // TODO: Update to contain JB Emergency Developers
         sphinxConfig.projectName = "nana-suckers-v5";
-        sphinxConfig.mainnets = ["ethereum", "optimism", "base", "arbitrum"];
-        sphinxConfig.testnets = ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia"];
+        sphinxConfig.mainnets = ["ethereum", "optimism", "base", "arbitrum", "celo"];
+        sphinxConfig.testnets = ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia", "celo_sepolia"];
     }
 
     function run() public {
@@ -371,6 +375,11 @@ contract DeployScript is Script, Sphinx {
             PRE_APPROVED_DEPLOYERS.push(
                 address(_deployCCIPSuckerFor(ARB_SALT, block.chainid == 1 ? CCIPHelper.ARB_ID : CCIPHelper.ARB_SEP_ID))
             );
+
+            // Celo (mainnet only — CCIP not available on Celo Sepolia).
+            if (block.chainid == 1) {
+                PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(CELO_SALT, CCIPHelper.CELO_ID)));
+            }
         }
 
         // Check if we should do the L2 portion.
@@ -399,6 +408,11 @@ contract DeployScript is Script, Sphinx {
                 )
             );
 
+            // ARB -> CELO (mainnet only — CCIP not available on Celo Sepolia).
+            if (block.chainid == 42_161) {
+                PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(ARB_CELO_SALT, CCIPHelper.CELO_ID)));
+            }
+
             // OP & OP Sepolia.
         } else if (block.chainid == 10 || block.chainid == 11_155_420) {
             // L1.
@@ -421,6 +435,11 @@ contract DeployScript is Script, Sphinx {
                     )
                 )
             );
+
+            // OP -> CELO (mainnet only — CCIP not available on Celo Sepolia).
+            if (block.chainid == 10) {
+                PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(OP_CELO_SALT, CCIPHelper.CELO_ID)));
+            }
 
             // BASE & BASE Sepolia.
         } else if (block.chainid == 8453 || block.chainid == 84_532) {
@@ -446,6 +465,25 @@ contract DeployScript is Script, Sphinx {
                     )
                 )
             );
+
+            // BASE -> CELO (mainnet only — CCIP not available on Celo Sepolia).
+            if (block.chainid == 8453) {
+                PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(BASE_CELO_SALT, CCIPHelper.CELO_ID)));
+            }
+
+            // Celo Mainnet (CCIP not available on Celo Sepolia).
+        } else if (block.chainid == 42_220) {
+            // CELO -> L1.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(CELO_SALT, CCIPHelper.ETH_ID)));
+
+            // CELO -> OP.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(OP_CELO_SALT, CCIPHelper.OP_ID)));
+
+            // CELO -> BASE.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(BASE_CELO_SALT, CCIPHelper.BASE_ID)));
+
+            // CELO -> ARB.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(ARB_CELO_SALT, CCIPHelper.ARB_ID)));
         }
     }
 

--- a/script/helpers/SuckerDeploymentLib.sol
+++ b/script/helpers/SuckerDeploymentLib.sol
@@ -14,6 +14,7 @@ struct SuckerDeployment {
     IJBSuckerDeployer optimismDeployer;
     IJBSuckerDeployer baseDeployer;
     IJBSuckerDeployer arbitrumDeployer;
+    IJBSuckerDeployer celoDeployer;
 }
 
 library SuckerDeploymentLib {
@@ -56,6 +57,7 @@ library SuckerDeploymentLib {
         bool _isOP = _network == keccak256("optimism") || _network == keccak256("optimism_sepolia");
         bool _isBase = _network == keccak256("base") || _network == keccak256("base_sepolia");
         bool _isArb = _network == keccak256("arbitrum") || _network == keccak256("arbitrum_sepolia");
+        bool _isCelo = _network == keccak256("celo") || _network == keccak256("celo_sepolia");
 
         if (_isMainnet || _isOP) {
             deployment.optimismDeployer = IJBSuckerDeployer(
@@ -71,6 +73,12 @@ library SuckerDeploymentLib {
         if (_isMainnet || _isArb) {
             deployment.arbitrumDeployer = IJBSuckerDeployer(
                 _getDeploymentAddress(path, "nana-suckers-v5", network_name, "JBArbitrumSuckerDeployer")
+            );
+        }
+
+        if (_isCelo) {
+            deployment.celoDeployer = IJBSuckerDeployer(
+                _getDeploymentAddress(path, "nana-suckers-v5", network_name, "JBCCIPSuckerDeployer")
             );
         }
     }

--- a/src/libraries/CCIPHelper.sol
+++ b/src/libraries/CCIPHelper.sol
@@ -15,6 +15,7 @@ library CCIPHelper {
     address public constant BNB_ROUTER = 0x34B03Cb9086d7D758AC55af71584F81A598759FE;
     address public constant BASE_ROUTER = 0x881e3A65B4d4a04dD529061dd0071cf975F58bCD;
     address public constant BASE_SEP_ROUTER = 0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6e88a93;
+    address public constant CELO_ROUTER = 0xfB48f15480926A4ADf9116Dca468bDd2EE6C5F62;
 
     /// @notice The respective chain ids per network
     uint256 public constant ETH_ID = 1;
@@ -28,6 +29,7 @@ library CCIPHelper {
     uint256 public constant BNB_ID = 56;
     uint256 public constant BASE_ID = 8453;
     uint256 public constant BASE_SEP_ID = 84_532;
+    uint256 public constant CELO_ID = 42_220;
 
     /// @notice The chain selector per network
     uint64 public constant ETH_SEL = 5_009_297_550_715_157_269;
@@ -41,6 +43,7 @@ library CCIPHelper {
     uint64 public constant BNB_SEL = 11_344_663_589_394_136_015;
     uint64 public constant BASE_SEL = 15_971_525_489_660_198_786;
     uint64 public constant BASE_SEP_SEL = 10_344_971_235_874_465_080;
+    uint64 public constant CELO_SEL = 1_346_049_177_634_351_622;
 
     /// @notice The WETH address of each chain
     address public constant ETH_WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
@@ -52,6 +55,7 @@ library CCIPHelper {
     address public constant AVA_WETH = 0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7;
     address public constant BNB_WETH = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
     address public constant BASE_WETH = 0x4200000000000000000000000000000000000006;
+    address public constant CELO_WETH = 0xD221812de1BD094f35587EE8E174B07B6167D9Af;
 
     function routerOfChain(uint256 _chainId) internal pure returns (address router) {
         if (_chainId == ETH_ID) {
@@ -76,6 +80,8 @@ library CCIPHelper {
             return OP_SEP_ROUTER;
         } else if (_chainId == BASE_SEP_ID) {
             return BASE_SEP_ROUTER;
+        } else if (_chainId == CELO_ID) {
+            return CELO_ROUTER;
         } else {
             revert("Unsupported chain");
         }
@@ -104,6 +110,8 @@ library CCIPHelper {
             return OP_SEP_SEL;
         } else if (_chainId == BASE_SEP_ID) {
             return BASE_SEP_SEL;
+        } else if (_chainId == CELO_ID) {
+            return CELO_SEL;
         } else {
             revert("Unsupported chain");
         }
@@ -128,6 +136,8 @@ library CCIPHelper {
             return ETH_SEP_WETH;
         } else if (_chainId == ARB_SEP_ID) {
             return ARB_SEP_WETH;
+        } else if (_chainId == CELO_ID) {
+            return CELO_WETH;
         } else {
             revert("Unsupported chain");
         }


### PR DESCRIPTION
- CCIPHelper: Celo mainnet constants (router, selector, WETH)
- Deploy: CCIP suckers for all Celo<->chain combinations (mainnet only)
- SuckerDeploymentLib: celoDeployer field for CCIP sucker reference
- CCIP not available on Celo Sepolia — Celo suckers are mainnet-only

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: