### PR TITLE
Rename MerkleLib error to follow ContractName_ErrorName convention

### DIFF
--- a/src/utils/MerkleLib.sol
+++ b/src/utils/MerkleLib.sol
@@ -10,7 +10,7 @@ pragma solidity 0.8.23;
 library MerkleLib {
     // ========== Custom Errors ===========
 
-    error MerkleLib__insert_treeIsFull();
+    error MerkleLib_InsertTreeIsFull();
 
     // ============ Constants =============
 
@@ -82,7 +82,7 @@ library MerkleLib {
     function insert(Tree memory tree, bytes32 node) internal pure returns (Tree memory) {
         // Update tree.count to increase the current count by 1 since we'll be including a new node.
         uint256 size = ++tree.count;
-        if (size > MAX_LEAVES) revert MerkleLib__insert_treeIsFull();
+        if (size > MAX_LEAVES) revert MerkleLib_InsertTreeIsFull();
 
         // Loop starting at 0, ending when we've finished inserting the node (i.e. hashing it) into
         // the active branch. Each loop we cut size in half, hashing the inserted node up the active
@@ -105,7 +105,7 @@ library MerkleLib {
         }
         // As the loop should always end prematurely with the `return` statement, this code should
         // be unreachable. We revert here just to be safe.
-        revert MerkleLib__insert_treeIsFull();
+        revert MerkleLib_InsertTreeIsFull();
     }
 
     // ========= Read Methods =========


### PR DESCRIPTION
MerkleLib__insert_treeIsFull -> MerkleLib_InsertTreeIsFull

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: