### PR TITLE
Rename trusted_forwarder to trustedForwarder, fix UNLICENSED licenses…

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -76,7 +76,7 @@ contract DeployScript is Script, Sphinx {
                 directory: core.directory,
                 permissions: core.permissions,
                 initialOwner: safeAddress(),
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             // Before transferring ownership to JBDAO we approve the deployers.
@@ -118,7 +118,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 configurator: safeAddress(),
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             _opDeployer.setChainSpecificConstants(
@@ -141,7 +141,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 addToBalanceMode: JBAddToBalanceMode.ON_CLAIM,
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             // Configure the deployer to use the singleton instance.
@@ -158,7 +158,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 configurator: safeAddress(),
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             _opDeployer.setChainSpecificConstants(
@@ -173,7 +173,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 addToBalanceMode: JBAddToBalanceMode.ON_CLAIM,
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             // Configure the deployer to use the singleton instance.
@@ -203,7 +203,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 configurator: safeAddress(),
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             _baseDeployer.setChainSpecificConstants(
@@ -226,7 +226,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 addToBalanceMode: JBAddToBalanceMode.ON_CLAIM,
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             // Configure the deployer to use the singleton instance.
@@ -243,7 +243,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 configurator: safeAddress(),
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             _baseDeployer.setChainSpecificConstants(
@@ -258,7 +258,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 addToBalanceMode: JBAddToBalanceMode.ON_CLAIM,
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             // Configure the deployer to use the singleton instance.
@@ -289,7 +289,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 configurator: safeAddress(),
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             _arbDeployer.setChainSpecificConstants({
@@ -307,7 +307,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 addToBalanceMode: JBAddToBalanceMode.ON_CLAIM,
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             // Configure the deployer to use the singleton instance.
@@ -324,7 +324,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 configurator: safeAddress(),
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             _arbDeployer.setChainSpecificConstants({
@@ -342,7 +342,7 @@ contract DeployScript is Script, Sphinx {
                 permissions: core.permissions,
                 tokens: core.tokens,
                 addToBalanceMode: JBAddToBalanceMode.ON_CLAIM,
-                trusted_forwarder: TRUSTED_FORWARDER
+                trustedForwarder: TRUSTED_FORWARDER
             });
 
             // Configure the deployer to use the singleton instance.
@@ -477,7 +477,7 @@ contract DeployScript is Script, Sphinx {
         IJBPermissions permissions,
         IJBTokens tokens,
         address configurator,
-        address trusted_forwarder,
+        address trustedForwarder,
         uint256 remoteChainId,
         uint64 remoteChainSelector,
         ICCIPRouter router
@@ -485,7 +485,7 @@ contract DeployScript is Script, Sphinx {
         internal
         returns (JBCCIPSuckerDeployer deployer)
     {
-        deployer = new JBCCIPSuckerDeployer{salt: salt}(directory, permissions, tokens, configurator, trusted_forwarder);
+        deployer = new JBCCIPSuckerDeployer{salt: salt}(directory, permissions, tokens, configurator, trustedForwarder);
 
         deployer.setChainSpecificConstants(remoteChainId, remoteChainSelector, router);
 
@@ -496,7 +496,7 @@ contract DeployScript is Script, Sphinx {
             tokens: tokens,
             permissions: permissions,
             addToBalanceMode: JBAddToBalanceMode.ON_CLAIM,
-            trusted_forwarder: trusted_forwarder
+            trustedForwarder: trustedForwarder
         });
 
         // Configure the singleton.

--- a/src/JBArbitrumSucker.sol
+++ b/src/JBArbitrumSucker.sol
@@ -70,9 +70,9 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         IJBPermissions permissions,
         IJBTokens tokens,
         JBAddToBalanceMode addToBalanceMode,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBSucker(directory, permissions, tokens, addToBalanceMode, trusted_forwarder)
+        JBSucker(directory, permissions, tokens, addToBalanceMode, trustedForwarder)
     {
         GATEWAYROUTER = JBArbitrumSuckerDeployer(deployer).arbGatewayRouter();
         ARBINBOX = JBArbitrumSuckerDeployer(deployer).arbInbox();

--- a/src/JBBaseSucker.sol
+++ b/src/JBBaseSucker.sol
@@ -19,9 +19,9 @@ contract JBBaseSucker is JBOptimismSucker {
         IJBPermissions permissions,
         IJBTokens tokens,
         JBAddToBalanceMode addToBalanceMode,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBOptimismSucker(deployer, directory, permissions, tokens, addToBalanceMode, trusted_forwarder)
+        JBOptimismSucker(deployer, directory, permissions, tokens, addToBalanceMode, trustedForwarder)
     {}
 
     //*********************************************************************//

--- a/src/JBCCIPSucker.sol
+++ b/src/JBCCIPSucker.sol
@@ -65,9 +65,9 @@ contract JBCCIPSucker is JBSucker, IAny2EVMMessageReceiver {
         IJBTokens tokens,
         IJBPermissions permissions,
         JBAddToBalanceMode addToBalanceMode,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBSucker(directory, permissions, tokens, addToBalanceMode, trusted_forwarder)
+        JBSucker(directory, permissions, tokens, addToBalanceMode, trustedForwarder)
     {
         REMOTE_CHAIN_ID = IJBCCIPSuckerDeployer(deployer).ccipRemoteChainId();
         REMOTE_CHAIN_SELECTOR = IJBCCIPSuckerDeployer(deployer).ccipRemoteChainSelector();

--- a/src/JBOptimismSucker.sol
+++ b/src/JBOptimismSucker.sol
@@ -52,9 +52,9 @@ contract JBOptimismSucker is JBSucker, IJBOptimismSucker {
         IJBPermissions permissions,
         IJBTokens tokens,
         JBAddToBalanceMode addToBalanceMode,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBSucker(directory, permissions, tokens, addToBalanceMode, trusted_forwarder)
+        JBSucker(directory, permissions, tokens, addToBalanceMode, trustedForwarder)
     {
         // Fetch the messenger and bridge by doing a callback to the deployer contract.
         OPBRIDGE = JBOptimismSuckerDeployer(deployer).opBridge();

--- a/src/JBSucker.sol
+++ b/src/JBSucker.sol
@@ -152,9 +152,9 @@ abstract contract JBSucker is ERC2771Context, JBPermissioned, Initializable, ERC
         IJBPermissions permissions,
         IJBTokens tokens,
         JBAddToBalanceMode addToBalanceMode,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        ERC2771Context(trusted_forwarder)
+        ERC2771Context(trustedForwarder)
         JBPermissioned(permissions)
     {
         DIRECTORY = directory;

--- a/src/JBSuckerRegistry.sol
+++ b/src/JBSuckerRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import {JBPermissioned} from "@bananapus/core-v5/src/abstract/JBPermissioned.sol";
@@ -76,9 +76,9 @@ contract JBSuckerRegistry is ERC2771Context, Ownable, JBPermissioned, IJBSuckerR
         IJBDirectory directory,
         IJBPermissions permissions,
         address initialOwner,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        ERC2771Context(trusted_forwarder)
+        ERC2771Context(trustedForwarder)
         JBPermissioned(permissions)
         Ownable(initialOwner)
     {

--- a/src/deployers/JBArbitrumSuckerDeployer.sol
+++ b/src/deployers/JBArbitrumSuckerDeployer.sol
@@ -38,9 +38,9 @@ contract JBArbitrumSuckerDeployer is JBSuckerDeployer, IJBArbitrumSuckerDeployer
         IJBPermissions permissions,
         IJBTokens tokens,
         address configurator,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBSuckerDeployer(directory, permissions, tokens, configurator, trusted_forwarder)
+        JBSuckerDeployer(directory, permissions, tokens, configurator, trustedForwarder)
     {}
 
     //*********************************************************************//

--- a/src/deployers/JBBaseSuckerDeployer.sol
+++ b/src/deployers/JBBaseSuckerDeployer.sol
@@ -19,8 +19,8 @@ contract JBBaseSuckerDeployer is JBOptimismSuckerDeployer {
         IJBPermissions permissions,
         IJBTokens tokens,
         address configurator,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBOptimismSuckerDeployer(directory, permissions, tokens, configurator, trusted_forwarder)
+        JBOptimismSuckerDeployer(directory, permissions, tokens, configurator, trustedForwarder)
     {}
 }

--- a/src/deployers/JBCCIPSuckerDeployer.sol
+++ b/src/deployers/JBCCIPSuckerDeployer.sol
@@ -42,9 +42,9 @@ contract JBCCIPSuckerDeployer is JBSuckerDeployer, IJBCCIPSuckerDeployer {
         IJBPermissions permissions,
         IJBTokens tokens,
         address configurator,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBSuckerDeployer(directory, permissions, tokens, configurator, trusted_forwarder)
+        JBSuckerDeployer(directory, permissions, tokens, configurator, trustedForwarder)
     {}
 
     //*********************************************************************//

--- a/src/deployers/JBOptimismSuckerDeployer.sol
+++ b/src/deployers/JBOptimismSuckerDeployer.sol
@@ -36,9 +36,9 @@ contract JBOptimismSuckerDeployer is JBSuckerDeployer, IJBOpSuckerDeployer {
         IJBPermissions permissions,
         IJBTokens tokens,
         address configurator,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        JBSuckerDeployer(directory, permissions, tokens, configurator, trusted_forwarder)
+        JBSuckerDeployer(directory, permissions, tokens, configurator, trustedForwarder)
     {}
 
     //*********************************************************************//

--- a/src/deployers/JBSuckerDeployer.sol
+++ b/src/deployers/JBSuckerDeployer.sol
@@ -51,9 +51,9 @@ abstract contract JBSuckerDeployer is ERC2771Context, JBPermissioned, IJBSuckerD
         IJBPermissions permissions,
         IJBTokens tokens,
         address configurator,
-        address trusted_forwarder
+        address trustedForwarder
     )
-        ERC2771Context(trusted_forwarder)
+        ERC2771Context(trustedForwarder)
         JBPermissioned(permissions)
     {
         DIRECTORY = directory;

--- a/src/extensions/JBAllowanceSucker.sol
+++ b/src/extensions/JBAllowanceSucker.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 import {IJBCashOutTerminal} from "@bananapus/core-v5/src/interfaces/IJBCashOutTerminal.sol";

--- a/src/interfaces/IJBSuckerRegistry.sol
+++ b/src/interfaces/IJBSuckerRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 import {IJBDirectory} from "@bananapus/core-v5/src/interfaces/IJBDirectory.sol";

--- a/test/Fork.t.sol
+++ b/test/Fork.t.sol
@@ -278,7 +278,7 @@ contract CCIPSuckerForkedTests is TestBaseWorkflow, JBTest {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             addToBalanceMode: JBAddToBalanceMode.MANUAL,
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
         vm.stopPrank();
 
@@ -338,7 +338,7 @@ contract CCIPSuckerForkedTests is TestBaseWorkflow, JBTest {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             addToBalanceMode: JBAddToBalanceMode.MANUAL,
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
         vm.stopPrank();
 

--- a/test/unit/deployer.t.sol
+++ b/test/unit/deployer.t.sol
@@ -137,7 +137,7 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             configurator: address(this),
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
 
         deployer = OPDeployer;
@@ -150,7 +150,7 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             addToBalanceMode: JBAddToBalanceMode.MANUAL,
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
 
         // Set the singleton.
@@ -173,7 +173,7 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             configurator: address(this),
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
 
         deployer = CCIPDeployer;
@@ -190,7 +190,7 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             addToBalanceMode: JBAddToBalanceMode.MANUAL,
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
 
         // Set the singleton.
@@ -214,7 +214,7 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             configurator: address(this),
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
 
         deployer = ARBDeployer;
@@ -227,7 +227,7 @@ contract DeployerTests is Test, TestBaseWorkflow, IERC721Receiver {
             permissions: jbPermissions(),
             tokens: jbTokens(),
             addToBalanceMode: JBAddToBalanceMode.MANUAL,
-            trusted_forwarder: address(0)
+            trustedForwarder: address(0)
         });
 
         // Set the singleton.


### PR DESCRIPTION
… to MIT

Standardize constructor parameter naming to camelCase (trustedForwarder) matching all other repos. Fix 3 SPDX license identifiers from UNLICENSED to MIT.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: