### PR TITLE
feat: add Tempo testnet support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,7 @@ ethereum_sepolia ="${RPC_ETHEREUM_SEPOLIA}"
 optimism_sepolia = "${RPC_OPTIMISM_SEPOLIA}"
 polygon_mumbai = "${RPC_POLYGON_MUMBAI}"
 base_sepolia = "${RPC_BASE_SEPOLIA}"
+tempo_testnet = "${RPC_TEMPO_TESTNET}"
 
 [profile.ci_sizes]
 optimizer_runs = 200

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -32,13 +32,19 @@ contract DeployScript is Script, Sphinx {
     bytes32 ARB_OP_SALT = "_SUCKER_ARB_OP_";
     bytes32 OP_BASE_SALT = "_SUCKER_OP_BASE_";
 
+    bytes32 TEMPO_SALT = "_SUCKER_ETH_TEMPO_";
+    bytes32 TEMPO_OP_SALT = "_SUCKER_OP_TEMPO_";
+    bytes32 TEMPO_BASE_SALT = "_SUCKER_BASE_TEMPO";
+    bytes32 TEMPO_ARB_SALT = "_SUCKER_ARB_TEMPO_";
+
     bytes32 REGISTRY_SALT = "REGISTRY";
 
     function configureSphinx() public override {
         // TODO: Update to contain JB Emergency Developers
         sphinxConfig.projectName = "nana-suckers-v5";
         sphinxConfig.mainnets = ["ethereum", "optimism", "base", "arbitrum"];
-        sphinxConfig.testnets = ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia"];
+        sphinxConfig.testnets =
+            ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia", "tempo_testnet"];
     }
 
     function run() public {
@@ -371,6 +377,11 @@ contract DeployScript is Script, Sphinx {
             PRE_APPROVED_DEPLOYERS.push(
                 address(_deployCCIPSuckerFor(ARB_SALT, block.chainid == 1 ? CCIPHelper.ARB_ID : CCIPHelper.ARB_SEP_ID))
             );
+
+            // Tempo (testnet only for now)
+            if (block.chainid == 11_155_111) {
+                PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(TEMPO_SALT, CCIPHelper.TEMPO_TEST_ID)));
+            }
         }
 
         // Check if we should do the L2 portion.
@@ -399,6 +410,11 @@ contract DeployScript is Script, Sphinx {
                 )
             );
 
+            // ARB -> TEMPO (testnet only).
+            if (block.chainid == 421_614) {
+                PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(TEMPO_ARB_SALT, CCIPHelper.TEMPO_TEST_ID)));
+            }
+
             // OP & OP Sepolia.
         } else if (block.chainid == 10 || block.chainid == 11_155_420) {
             // L1.
@@ -421,6 +437,11 @@ contract DeployScript is Script, Sphinx {
                     )
                 )
             );
+
+            // OP -> TEMPO (testnet only).
+            if (block.chainid == 11_155_420) {
+                PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(TEMPO_OP_SALT, CCIPHelper.TEMPO_TEST_ID)));
+            }
 
             // BASE & BASE Sepolia.
         } else if (block.chainid == 8453 || block.chainid == 84_532) {
@@ -446,6 +467,27 @@ contract DeployScript is Script, Sphinx {
                     )
                 )
             );
+
+            // BASE -> TEMPO (testnet only).
+            if (block.chainid == 84_532) {
+                PRE_APPROVED_DEPLOYERS.push(
+                    address(_deployCCIPSuckerFor(TEMPO_BASE_SALT, CCIPHelper.TEMPO_TEST_ID))
+                );
+            }
+
+            // Tempo testnet.
+        } else if (block.chainid == 42_429) {
+            // TEMPO -> ETH.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(TEMPO_SALT, CCIPHelper.ETH_SEP_ID)));
+
+            // TEMPO -> OP.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(TEMPO_OP_SALT, CCIPHelper.OP_SEP_ID)));
+
+            // TEMPO -> BASE.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(TEMPO_BASE_SALT, CCIPHelper.BASE_SEP_ID)));
+
+            // TEMPO -> ARB.
+            PRE_APPROVED_DEPLOYERS.push(address(_deployCCIPSuckerFor(TEMPO_ARB_SALT, CCIPHelper.ARB_SEP_ID)));
         }
     }
 

--- a/script/helpers/SuckerDeploymentLib.sol
+++ b/script/helpers/SuckerDeploymentLib.sol
@@ -14,6 +14,7 @@ struct SuckerDeployment {
     IJBSuckerDeployer optimismDeployer;
     IJBSuckerDeployer baseDeployer;
     IJBSuckerDeployer arbitrumDeployer;
+    IJBSuckerDeployer tempoDeployer;
 }
 
 library SuckerDeploymentLib {
@@ -56,6 +57,7 @@ library SuckerDeploymentLib {
         bool _isOP = _network == keccak256("optimism") || _network == keccak256("optimism_sepolia");
         bool _isBase = _network == keccak256("base") || _network == keccak256("base_sepolia");
         bool _isArb = _network == keccak256("arbitrum") || _network == keccak256("arbitrum_sepolia");
+        bool _isTempo = _network == keccak256("tempo_testnet");
 
         if (_isMainnet || _isOP) {
             deployment.optimismDeployer = IJBSuckerDeployer(
@@ -71,6 +73,12 @@ library SuckerDeploymentLib {
         if (_isMainnet || _isArb) {
             deployment.arbitrumDeployer = IJBSuckerDeployer(
                 _getDeploymentAddress(path, "nana-suckers-v5", network_name, "JBArbitrumSuckerDeployer")
+            );
+        }
+
+        if (_isTempo || _isMainnet) {
+            deployment.tempoDeployer = IJBSuckerDeployer(
+                _getDeploymentAddress(path, "nana-suckers-v5", network_name, "JBCCIPSuckerDeployer")
             );
         }
     }

--- a/src/libraries/CCIPHelper.sol
+++ b/src/libraries/CCIPHelper.sol
@@ -15,6 +15,7 @@ library CCIPHelper {
     address public constant BNB_ROUTER = 0x34B03Cb9086d7D758AC55af71584F81A598759FE;
     address public constant BASE_ROUTER = 0x881e3A65B4d4a04dD529061dd0071cf975F58bCD;
     address public constant BASE_SEP_ROUTER = 0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6e88a93;
+    address public constant TEMPO_TEST_ROUTER = 0xAE7D1b3D8466718378038de45D4D376E73A04EB6;
 
     /// @notice The respective chain ids per network
     uint256 public constant ETH_ID = 1;
@@ -28,6 +29,7 @@ library CCIPHelper {
     uint256 public constant BNB_ID = 56;
     uint256 public constant BASE_ID = 8453;
     uint256 public constant BASE_SEP_ID = 84_532;
+    uint256 public constant TEMPO_TEST_ID = 42_429;
 
     /// @notice The chain selector per network
     uint64 public constant ETH_SEL = 5_009_297_550_715_157_269;
@@ -41,6 +43,7 @@ library CCIPHelper {
     uint64 public constant BNB_SEL = 11_344_663_589_394_136_015;
     uint64 public constant BASE_SEL = 15_971_525_489_660_198_786;
     uint64 public constant BASE_SEP_SEL = 10_344_971_235_874_465_080;
+    uint64 public constant TEMPO_TEST_SEL = 3_963_528_237_232_804_922;
 
     /// @notice The WETH address of each chain
     address public constant ETH_WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
@@ -52,6 +55,8 @@ library CCIPHelper {
     address public constant AVA_WETH = 0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7;
     address public constant BNB_WETH = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
     address public constant BASE_WETH = 0x4200000000000000000000000000000000000006;
+    /// @notice WTEMP (wrapped native USD) on Tempo testnet — follows naming convention of POLY_WETH (WMATIC), AVA_WETH (WAVAX), etc.
+    address public constant TEMPO_TEST_WETH = 0xe875EB5437E55B74D18f6C090a5A14e4804dB2d9;
 
     function routerOfChain(uint256 _chainId) internal pure returns (address router) {
         if (_chainId == ETH_ID) {
@@ -76,6 +81,8 @@ library CCIPHelper {
             return OP_SEP_ROUTER;
         } else if (_chainId == BASE_SEP_ID) {
             return BASE_SEP_ROUTER;
+        } else if (_chainId == TEMPO_TEST_ID) {
+            return TEMPO_TEST_ROUTER;
         } else {
             revert("Unsupported chain");
         }
@@ -104,6 +111,8 @@ library CCIPHelper {
             return OP_SEP_SEL;
         } else if (_chainId == BASE_SEP_ID) {
             return BASE_SEP_SEL;
+        } else if (_chainId == TEMPO_TEST_ID) {
+            return TEMPO_TEST_SEL;
         } else {
             revert("Unsupported chain");
         }
@@ -128,6 +137,8 @@ library CCIPHelper {
             return ETH_SEP_WETH;
         } else if (_chainId == ARB_SEP_ID) {
             return ARB_SEP_WETH;
+        } else if (_chainId == TEMPO_TEST_ID) {
+            return TEMPO_TEST_WETH;
         } else {
             revert("Unsupported chain");
         }

--- a/test/TempoAttacks.t.sol
+++ b/test/TempoAttacks.t.sol
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {IJBController} from "@bananapus/core-v5/src/interfaces/IJBController.sol";
+import {IJBDirectory} from "@bananapus/core-v5/src/interfaces/IJBDirectory.sol";
+import {IJBPermissions} from "@bananapus/core-v5/src/interfaces/IJBPermissions.sol";
+import {IJBTokens} from "@bananapus/core-v5/src/interfaces/IJBTokens.sol";
+import {JBConstants} from "@bananapus/core-v5/src/libraries/JBConstants.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {LibClone} from "solady/src/utils/LibClone.sol";
+
+import "../src/JBSucker.sol";
+import {JBAddToBalanceMode} from "../src/enums/JBAddToBalanceMode.sol";
+import {JBSuckerState} from "../src/enums/JBSuckerState.sol";
+import {JBClaim} from "../src/structs/JBClaim.sol";
+import {JBLeaf} from "../src/structs/JBLeaf.sol";
+import {JBInboxTreeRoot} from "../src/structs/JBInboxTreeRoot.sol";
+import {JBMessageRoot} from "../src/structs/JBMessageRoot.sol";
+import {JBRemoteToken} from "../src/structs/JBRemoteToken.sol";
+import {JBTokenMapping} from "../src/structs/JBTokenMapping.sol";
+import {MerkleLib} from "../src/utils/MerkleLib.sol";
+
+/// @notice Reusable test sucker for attack testing.
+contract AttackTempoSucker is JBSucker {
+    using MerkleLib for MerkleLib.Tree;
+
+    bool nextCheckShouldPass;
+
+    constructor(
+        IJBDirectory directory,
+        IJBPermissions permissions,
+        IJBTokens tokens,
+        JBAddToBalanceMode addToBalanceMode,
+        address forwarder
+    ) JBSucker(directory, permissions, tokens, addToBalanceMode, forwarder) {}
+
+    function _sendRootOverAMB(
+        uint256,
+        uint256,
+        address,
+        uint256,
+        JBRemoteToken memory,
+        JBMessageRoot memory
+    ) internal override {}
+
+    function _isRemotePeer(address sender) internal view override returns (bool) {
+        return sender == peer();
+    }
+
+    function peerChainId() external view virtual override returns (uint256) {
+        return block.chainid;
+    }
+
+    function _validateBranchRoot(
+        bytes32 expectedRoot,
+        uint256 projectTokenCount,
+        uint256 terminalTokenAmount,
+        address beneficiary,
+        uint256 index,
+        bytes32[_TREE_DEPTH] calldata leaves
+    ) internal virtual override {
+        if (!nextCheckShouldPass) {
+            super._validateBranchRoot(expectedRoot, projectTokenCount, terminalTokenAmount, beneficiary, index, leaves);
+        }
+        nextCheckShouldPass = false;
+    }
+
+    function test_setNextMerkleCheckToBe(bool _pass) external {
+        nextCheckShouldPass = _pass;
+    }
+
+    function test_setOutboxBalance(address token, uint256 amount) external {
+        _outboxOf[token].balance = amount;
+    }
+
+    function test_setInboxRoot(address token, uint64 nonce, bytes32 root) external {
+        _inboxOf[token] = JBInboxTreeRoot({nonce: nonce, root: root});
+    }
+
+    function test_insertIntoTree(
+        uint256 projectTokenCount,
+        address token,
+        uint256 terminalTokenAmount,
+        address beneficiary
+    ) external {
+        _insertIntoTree(projectTokenCount, token, terminalTokenAmount, beneficiary);
+    }
+
+    function test_getOutboxRoot(address token) external view returns (bytes32) {
+        return _outboxOf[token].tree.root();
+    }
+
+    function test_getOutboxCount(address token) external view returns (uint256) {
+        return _outboxOf[token].tree.count;
+    }
+
+    function test_getInboxNonce(address token) external view returns (uint64) {
+        return _inboxOf[token].nonce;
+    }
+
+    function test_getInboxRoot(address token) external view returns (bytes32) {
+        return _inboxOf[token].root;
+    }
+
+    function test_setRemoteToken(address localToken, JBRemoteToken memory remoteToken) external {
+        _remoteTokenFor[localToken] = remoteToken;
+    }
+
+    function test_setDeprecatedAfter(uint40 ts) external {
+        deprecatedAfter = ts;
+    }
+}
+
+/// @title TempoAttacks
+/// @notice Attack surface testing for the Tempo cross-chain integration.
+/// @dev Tests re-entrancy vectors, double-claiming, front-running, and cross-chain accounting invariants
+///      specific to the mixed NATIVE_TOKEN/ERC20 architecture of Tempo.
+contract TempoAttacks is Test {
+    using MerkleLib for MerkleLib.Tree;
+
+    address constant DIRECTORY = address(600);
+    address constant PERMISSIONS = address(800);
+    address constant TOKENS = address(700);
+    address constant CONTROLLER = address(900);
+    address constant PROJECT = address(1000);
+    address constant FORWARDER = address(1100);
+
+    uint256 constant PROJECT_ID = 1;
+
+    /// @dev Simulated WETH ERC20 on Tempo
+    address constant WETH_ON_TEMPO = address(0xE770e770E770E770e770e770E770e770E770E770);
+
+    AttackTempoSucker sucker;
+
+    function setUp() public {
+        vm.label(DIRECTORY, "MOCK_DIRECTORY");
+        vm.label(PERMISSIONS, "MOCK_PERMISSIONS");
+
+        sucker = _createTestSucker(PROJECT_ID, "attack_salt");
+
+        vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.PROJECTS, ()), abi.encode(PROJECT));
+        vm.mockCall(PROJECT, abi.encodeCall(IERC721.ownerOf, (PROJECT_ID)), abi.encode(address(this)));
+    }
+
+    function _createTestSucker(uint256 projectId, bytes32 salt) internal returns (AttackTempoSucker) {
+        AttackTempoSucker singleton = new AttackTempoSucker(
+            IJBDirectory(DIRECTORY), IJBPermissions(PERMISSIONS), IJBTokens(TOKENS), JBAddToBalanceMode.MANUAL, FORWARDER
+        );
+
+        AttackTempoSucker clone =
+            AttackTempoSucker(payable(address(LibClone.cloneDeterministic(address(singleton), salt))));
+        clone.initialize(projectId);
+        return clone;
+    }
+
+    // =========================================================================
+    // INVARIANT 1: No tokens created from nothing
+    // =========================================================================
+    /// @notice Outbox balance can only increase through insertIntoTree.
+    ///         Direct balance manipulation should not affect tracked outbox balance.
+    function test_invariant_noTokensFromNothing() public {
+        address token = WETH_ON_TEMPO;
+
+        // Track initial outbox balance (0)
+        uint256 trackedBalance = 0;
+
+        // Insert items — this is the ONLY way to increase outbox balance
+        sucker.test_insertIntoTree(5 ether, token, 3 ether, address(100));
+        sucker.test_insertIntoTree(10 ether, token, 7 ether, address(200));
+        trackedBalance += 3 ether + 7 ether;
+
+        // Outbox count should reflect insertions
+        assertEq(sucker.test_getOutboxCount(token), 2, "Should have 2 leaves");
+
+        // Sending extra tokens to the sucker should NOT increase outbox balance
+        // (outbox.balance is only increased through _insertIntoTree in prepare())
+        vm.deal(address(sucker), 100 ether);
+
+        // The actual balance is inflated but the tracked outbox is not
+        assertEq(address(sucker).balance, 100 ether, "ETH balance should be inflated");
+        // Outbox tree count remains 2 — no phantom leaves created
+        assertEq(sucker.test_getOutboxCount(token), 2, "Outbox count should still be 2");
+    }
+
+    // =========================================================================
+    // INVARIANT 2: No double-spend across different token types
+    // =========================================================================
+    /// @notice Claiming a leaf for WETH_ON_TEMPO should not allow claiming the same
+    ///         leaf index for NATIVE_TOKEN or vice versa.
+    function test_invariant_noDoubleSpendAcrossTokenTypes() public {
+        address wethToken = WETH_ON_TEMPO;
+        address nativeToken = JBConstants.NATIVE_TOKEN;
+
+        // Set up leaves for both token types at the same index (0)
+        sucker.test_insertIntoTree(5 ether, wethToken, 5 ether, address(120));
+        sucker.test_insertIntoTree(5 ether, nativeToken, 5 ether, address(120));
+
+        // Set inbox roots
+        bytes32 wethRoot = sucker.test_getOutboxRoot(wethToken);
+        bytes32 nativeRoot = sucker.test_getOutboxRoot(nativeToken);
+        sucker.test_setInboxRoot(wethToken, 1, wethRoot);
+        sucker.test_setInboxRoot(nativeToken, 1, nativeRoot);
+        sucker.test_setOutboxBalance(wethToken, 100 ether);
+        sucker.test_setOutboxBalance(nativeToken, 100 ether);
+
+        // Mock controller
+        vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.controllerOf, (PROJECT_ID)), abi.encode(CONTROLLER));
+        vm.mockCall(
+            CONTROLLER,
+            abi.encodeCall(IJBController.mintTokensOf, (PROJECT_ID, 5 ether, address(120), "", false)),
+            abi.encode(5 ether)
+        );
+
+        bytes32[32] memory proof;
+
+        // Claim for WETH_ON_TEMPO at index 0
+        sucker.test_setNextMerkleCheckToBe(true);
+        JBClaim memory wethClaim = JBClaim({
+            token: wethToken,
+            leaf: JBLeaf({index: 0, beneficiary: address(120), projectTokenCount: 5 ether, terminalTokenAmount: 5 ether}),
+            proof: proof
+        });
+        sucker.claim(wethClaim);
+
+        // Claim for NATIVE_TOKEN at index 0 should ALSO succeed (separate bitmap per token)
+        sucker.test_setNextMerkleCheckToBe(true);
+        JBClaim memory nativeClaim = JBClaim({
+            token: nativeToken,
+            leaf: JBLeaf({index: 0, beneficiary: address(120), projectTokenCount: 5 ether, terminalTokenAmount: 5 ether}),
+            proof: proof
+        });
+        sucker.claim(nativeClaim);
+
+        // But claiming WETH again at index 0 should revert
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_LeafAlreadyExecuted.selector, wethToken, 0));
+        sucker.claim(wethClaim);
+
+        // And claiming NATIVE again at index 0 should revert
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_LeafAlreadyExecuted.selector, nativeToken, 0));
+        sucker.claim(nativeClaim);
+    }
+
+    // =========================================================================
+    // ATTACK 1: Front-running token mapping change
+    // =========================================================================
+    /// @notice An attacker cannot exploit a token mapping change to claim tokens that don't belong to them.
+    ///         Inbox roots are keyed by local token address, independent of the remote mapping.
+    function test_attack_frontRunTokenMappingChange() public {
+        address token = WETH_ON_TEMPO;
+
+        // Set up remote mapping: WETH_ON_TEMPO → NATIVE_TOKEN on ETH
+        sucker.test_setRemoteToken(
+            token,
+            JBRemoteToken({
+                enabled: true,
+                emergencyHatch: false,
+                minGas: 200_000,
+                addr: JBConstants.NATIVE_TOKEN,
+                minBridgeAmount: 0
+            })
+        );
+
+        // Insert leaf and set inbox root
+        sucker.test_insertIntoTree(10 ether, token, 5 ether, address(100));
+        bytes32 root = sucker.test_getOutboxRoot(token);
+        sucker.test_setInboxRoot(token, 1, root);
+
+        // Attacker changes the remote mapping (would need to be project owner)
+        address maliciousRemote = makeAddr("maliciousRemote");
+        sucker.test_setRemoteToken(
+            token,
+            JBRemoteToken({
+                enabled: true,
+                emergencyHatch: false,
+                minGas: 200_000,
+                addr: maliciousRemote,
+                minBridgeAmount: 0
+            })
+        );
+
+        // The inbox root for WETH_ON_TEMPO is still valid — it's keyed by local token, not remote
+        bytes32 storedRoot = sucker.test_getInboxRoot(token);
+        assertEq(storedRoot, root, "Inbox root should persist regardless of remote mapping change");
+    }
+
+    // =========================================================================
+    // ATTACK 2: Cross-token inbox root confusion
+    // =========================================================================
+    /// @notice Attacker tries to claim using a proof from one token type against another token's inbox.
+    function test_attack_crossTokenInboxConfusion() public {
+        // Set up roots for two different tokens with different merkle trees
+        sucker.test_insertIntoTree(10 ether, WETH_ON_TEMPO, 5 ether, address(100));
+        sucker.test_insertIntoTree(20 ether, JBConstants.NATIVE_TOKEN, 10 ether, address(200));
+
+        bytes32 wethRoot = sucker.test_getOutboxRoot(WETH_ON_TEMPO);
+        bytes32 nativeRoot = sucker.test_getOutboxRoot(JBConstants.NATIVE_TOKEN);
+
+        // Set inbox roots
+        sucker.test_setInboxRoot(WETH_ON_TEMPO, 1, wethRoot);
+        sucker.test_setInboxRoot(JBConstants.NATIVE_TOKEN, 1, nativeRoot);
+
+        // The roots should be different since different data was inserted
+        assertTrue(wethRoot != nativeRoot, "Different trees should produce different roots");
+
+        // An attacker cannot use WETH proof against NATIVE inbox or vice versa
+        // because the claim token determines which inbox root is checked
+    }
+
+    // =========================================================================
+    // ATTACK 3: Deprecated sucker message injection
+    // =========================================================================
+    /// @notice When a sucker is deprecated, fromRemote silently ignores new messages.
+    ///         This prevents attackers from injecting messages into a deprecated sucker.
+    function test_attack_deprecatedSuckerMessageInjection() public {
+        // Warp to a realistic timestamp to avoid underflow in state() calculation.
+        // state() computes deprecatedAfter - _maxMessagingDelay() (14 days) which underflows
+        // at low timestamps.
+        vm.warp(30 days);
+
+        // Deprecate the sucker
+        sucker.test_setDeprecatedAfter(uint40(block.timestamp + 1));
+        vm.warp(block.timestamp + 1);
+        assertEq(uint8(sucker.state()), uint8(JBSuckerState.DEPRECATED));
+
+        // Try to inject a message
+        JBMessageRoot memory root = JBMessageRoot({
+            token: WETH_ON_TEMPO,
+            amount: 1000 ether,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xDEAD))})
+        });
+
+        // fromRemote should accept the call but silently ignore the update
+        vm.prank(address(sucker));
+        sucker.fromRemote(root);
+
+        // Verify the inbox was NOT updated
+        assertEq(sucker.test_getInboxNonce(WETH_ON_TEMPO), 0, "Inbox should not update when deprecated");
+    }
+
+    // =========================================================================
+    // ATTACK 4: Nonce gap exploitation
+    // =========================================================================
+    /// @notice Verify that nonce gaps are accepted (1→5 is valid).
+    ///         An attacker cannot cause issues by skipping nonces.
+    function test_attack_nonceGapExploitation() public {
+        // Deliver nonce 1
+        vm.prank(address(sucker));
+        sucker.fromRemote(
+            JBMessageRoot({
+                token: WETH_ON_TEMPO,
+                amount: 1 ether,
+                remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xAA))})
+            })
+        );
+        assertEq(sucker.test_getInboxNonce(WETH_ON_TEMPO), 1);
+
+        // Skip to nonce 5 — this should be accepted
+        vm.prank(address(sucker));
+        sucker.fromRemote(
+            JBMessageRoot({
+                token: WETH_ON_TEMPO,
+                amount: 1 ether,
+                remoteRoot: JBInboxTreeRoot({nonce: 5, root: bytes32(uint256(0xBB))})
+            })
+        );
+        assertEq(sucker.test_getInboxNonce(WETH_ON_TEMPO), 5, "Nonce gap should be accepted");
+
+        // Nonce 3 (which was skipped) should be silently ignored
+        vm.prank(address(sucker));
+        sucker.fromRemote(
+            JBMessageRoot({
+                token: WETH_ON_TEMPO,
+                amount: 1 ether,
+                remoteRoot: JBInboxTreeRoot({nonce: 3, root: bytes32(uint256(0xCC))})
+            })
+        );
+        assertEq(sucker.test_getInboxNonce(WETH_ON_TEMPO), 5, "Stale nonce 3 should be ignored");
+    }
+
+    // =========================================================================
+    // ATTACK 5: Claim with beneficiary mismatch
+    // =========================================================================
+    /// @notice Attacker tries to claim tokens intended for a different beneficiary
+    ///         by constructing a claim with their own address. The merkle proof
+    ///         validation should prevent this.
+    function test_attack_beneficiaryMismatch() public {
+        address token = WETH_ON_TEMPO;
+        address realBeneficiary = address(100);
+        address attacker = address(999);
+
+        // Insert leaf for real beneficiary
+        sucker.test_insertIntoTree(5 ether, token, 5 ether, realBeneficiary);
+        bytes32 root = sucker.test_getOutboxRoot(token);
+        sucker.test_setInboxRoot(token, 1, root);
+        sucker.test_setOutboxBalance(token, 100 ether);
+
+        // Attacker tries to claim with their own address but the proof won't match
+        // (merkle check is NOT overridden here)
+        bytes32[32] memory proof;
+        JBClaim memory attackClaim = JBClaim({
+            token: token,
+            leaf: JBLeaf({
+                index: 0,
+                beneficiary: attacker, // Wrong beneficiary
+                projectTokenCount: 5 ether,
+                terminalTokenAmount: 5 ether
+            }),
+            proof: proof
+        });
+
+        // This should revert because the merkle proof doesn't match the modified beneficiary
+        vm.expectRevert();
+        sucker.claim(attackClaim);
+    }
+
+    // =========================================================================
+    // INVARIANT 3: Outbox tree count is monotonically increasing
+    // =========================================================================
+    /// @notice The outbox tree count can only increase, never decrease.
+    function test_invariant_outboxCountMonotonic() public {
+        address token = WETH_ON_TEMPO;
+
+        uint256 prevCount = 0;
+        for (uint256 i = 0; i < 20; i++) {
+            sucker.test_insertIntoTree(
+                (i + 1) * 1 ether, token, (i + 1) * 0.5 ether, address(uint160(1000 + i))
+            );
+
+            uint256 newCount = sucker.test_getOutboxCount(token);
+            assertTrue(newCount > prevCount, "Count must strictly increase");
+            prevCount = newCount;
+        }
+
+        assertEq(prevCount, 20, "Final count should be 20");
+    }
+
+    // =========================================================================
+    // INVARIANT 4: Inbox nonce is monotonically increasing per token
+    // =========================================================================
+    /// @notice Inbox nonce can only increase, never decrease, independently per token.
+    function test_invariant_inboxNonceMonotonic() public {
+        uint64 wethNonce = 0;
+        uint64 nativeNonce = 0;
+
+        for (uint64 i = 1; i <= 10; i++) {
+            // Advance WETH nonce
+            vm.prank(address(sucker));
+            sucker.fromRemote(
+                JBMessageRoot({
+                    token: WETH_ON_TEMPO,
+                    amount: 1 ether,
+                    remoteRoot: JBInboxTreeRoot({nonce: i, root: bytes32(uint256(i))})
+                })
+            );
+            uint64 newWethNonce = sucker.test_getInboxNonce(WETH_ON_TEMPO);
+            assertTrue(newWethNonce > wethNonce, "WETH nonce must increase");
+            wethNonce = newWethNonce;
+
+            // Advance NATIVE nonce at 2x rate
+            vm.prank(address(sucker));
+            sucker.fromRemote(
+                JBMessageRoot({
+                    token: JBConstants.NATIVE_TOKEN,
+                    amount: 1 ether,
+                    remoteRoot: JBInboxTreeRoot({nonce: i * 2, root: bytes32(uint256(i * 100))})
+                })
+            );
+            uint64 newNativeNonce = sucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN);
+            assertTrue(newNativeNonce > nativeNonce, "NATIVE nonce must increase");
+            nativeNonce = newNativeNonce;
+        }
+
+        assertEq(wethNonce, 10, "Final WETH nonce should be 10");
+        assertEq(nativeNonce, 20, "Final NATIVE nonce should be 20");
+    }
+
+    receive() external payable {}
+}

--- a/test/TempoSuckerSecurity.t.sol
+++ b/test/TempoSuckerSecurity.t.sol
@@ -1,0 +1,529 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {IJBController} from "@bananapus/core-v5/src/interfaces/IJBController.sol";
+import {IJBDirectory} from "@bananapus/core-v5/src/interfaces/IJBDirectory.sol";
+import {IJBPermissions} from "@bananapus/core-v5/src/interfaces/IJBPermissions.sol";
+import {IJBTokens} from "@bananapus/core-v5/src/interfaces/IJBTokens.sol";
+import {JBConstants} from "@bananapus/core-v5/src/libraries/JBConstants.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {LibClone} from "solady/src/utils/LibClone.sol";
+
+import "../src/JBSucker.sol";
+import {JBAddToBalanceMode} from "../src/enums/JBAddToBalanceMode.sol";
+import {JBSuckerState} from "../src/enums/JBSuckerState.sol";
+import {JBClaim} from "../src/structs/JBClaim.sol";
+import {JBLeaf} from "../src/structs/JBLeaf.sol";
+import {JBInboxTreeRoot} from "../src/structs/JBInboxTreeRoot.sol";
+import {JBMessageRoot} from "../src/structs/JBMessageRoot.sol";
+import {JBRemoteToken} from "../src/structs/JBRemoteToken.sol";
+import {JBTokenMapping} from "../src/structs/JBTokenMapping.sol";
+import {MerkleLib} from "../src/utils/MerkleLib.sol";
+import {CCIPHelper} from "../src/libraries/CCIPHelper.sol";
+
+/// @notice A test sucker that exposes internals and supports mixed NATIVE/ERC20 token scenarios.
+contract TempoTestSucker is JBSucker {
+    using MerkleLib for MerkleLib.Tree;
+
+    bool nextCheckShouldPass;
+
+    constructor(
+        IJBDirectory directory,
+        IJBPermissions permissions,
+        IJBTokens tokens,
+        JBAddToBalanceMode addToBalanceMode,
+        address forwarder
+    ) JBSucker(directory, permissions, tokens, addToBalanceMode, forwarder) {}
+
+    function _sendRootOverAMB(
+        uint256,
+        uint256,
+        address,
+        uint256,
+        JBRemoteToken memory,
+        JBMessageRoot memory
+    ) internal override {}
+
+    function _isRemotePeer(address sender) internal view override returns (bool) {
+        return sender == peer();
+    }
+
+    function peerChainId() external view virtual override returns (uint256) {
+        return block.chainid;
+    }
+
+    function _validateBranchRoot(
+        bytes32 expectedRoot,
+        uint256 projectTokenCount,
+        uint256 terminalTokenAmount,
+        address beneficiary,
+        uint256 index,
+        bytes32[_TREE_DEPTH] calldata leaves
+    ) internal virtual override {
+        if (!nextCheckShouldPass) {
+            super._validateBranchRoot(expectedRoot, projectTokenCount, terminalTokenAmount, beneficiary, index, leaves);
+        }
+        nextCheckShouldPass = false;
+    }
+
+    // Test helpers
+    function test_setNextMerkleCheckToBe(bool _pass) external {
+        nextCheckShouldPass = _pass;
+    }
+
+    function test_setOutboxBalance(address token, uint256 amount) external {
+        _outboxOf[token].balance = amount;
+    }
+
+    function test_setInboxRoot(address token, uint64 nonce, bytes32 root) external {
+        _inboxOf[token] = JBInboxTreeRoot({nonce: nonce, root: root});
+    }
+
+    function test_insertIntoTree(
+        uint256 projectTokenCount,
+        address token,
+        uint256 terminalTokenAmount,
+        address beneficiary
+    ) external {
+        _insertIntoTree(projectTokenCount, token, terminalTokenAmount, beneficiary);
+    }
+
+    function test_getOutboxRoot(address token) external view returns (bytes32) {
+        return _outboxOf[token].tree.root();
+    }
+
+    function test_getOutboxCount(address token) external view returns (uint256) {
+        return _outboxOf[token].tree.count;
+    }
+
+    function test_getInboxRoot(address token) external view returns (bytes32) {
+        return _inboxOf[token].root;
+    }
+
+    function test_getInboxNonce(address token) external view returns (uint64) {
+        return _inboxOf[token].nonce;
+    }
+
+    function test_setRemoteToken(address localToken, JBRemoteToken memory remoteToken) external {
+        _remoteTokenFor[localToken] = remoteToken;
+    }
+}
+
+/// @title TempoSuckerSecurity
+/// @notice Security tests for Tempo blockchain integration, focusing on mixed NATIVE_TOKEN/ERC20 token mappings.
+/// @dev Tempo's native token is USD (not ETH). ETH exists only as an ERC20 (WETH) on Tempo.
+///      This test suite validates that the sucker system handles this architecture correctly.
+contract TempoSuckerSecurity is Test {
+    using MerkleLib for MerkleLib.Tree;
+
+    address constant DIRECTORY = address(600);
+    address constant PERMISSIONS = address(800);
+    address constant TOKENS = address(700);
+    address constant CONTROLLER = address(900);
+    address constant PROJECT = address(1000);
+    address constant FORWARDER = address(1100);
+
+    uint256 constant PROJECT_ID = 1;
+
+    /// @dev Simulated WETH ERC20 address on Tempo (not NATIVE_TOKEN)
+    address constant WETH_ON_TEMPO = address(0xE770e770E770E770e770e770E770e770E770E770);
+
+    /// @dev WTEMP is wrapped native USD on Tempo — NOT the same as WETH
+    address constant WTEMP = 0xe875EB5437E55B74D18f6C090a5A14e4804dB2d9;
+
+    TempoTestSucker ethSucker; // Sucker on ETH side
+    TempoTestSucker tempoSucker; // Sucker on Tempo side
+
+    function setUp() public {
+        vm.label(DIRECTORY, "MOCK_DIRECTORY");
+        vm.label(PERMISSIONS, "MOCK_PERMISSIONS");
+        vm.label(TOKENS, "MOCK_TOKENS");
+        vm.label(CONTROLLER, "MOCK_CONTROLLER");
+
+        ethSucker = _createTestSucker(PROJECT_ID, "eth_sucker");
+        tempoSucker = _createTestSucker(PROJECT_ID, "tempo_sucker");
+
+        // Mock directory
+        vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.PROJECTS, ()), abi.encode(PROJECT));
+        vm.mockCall(PROJECT, abi.encodeCall(IERC721.ownerOf, (PROJECT_ID)), abi.encode(address(this)));
+    }
+
+    function _createTestSucker(uint256 projectId, bytes32 salt) internal returns (TempoTestSucker) {
+        TempoTestSucker singleton = new TempoTestSucker(
+            IJBDirectory(DIRECTORY), IJBPermissions(PERMISSIONS), IJBTokens(TOKENS), JBAddToBalanceMode.MANUAL, FORWARDER
+        );
+
+        TempoTestSucker clone =
+            TempoTestSucker(payable(address(LibClone.cloneDeterministic(address(singleton), salt))));
+        clone.initialize(projectId);
+        return clone;
+    }
+
+    // =========================================================================
+    // Test 1: Mixed NATIVE/ERC20 mapping — ETH→Tempo direction
+    // =========================================================================
+    /// @notice When NATIVE_TOKEN on ETH maps to WETH_ON_TEMPO (ERC20), the sucker on Tempo
+    ///         should NOT attempt to unwrap the received token. The inbox should be keyed by WETH_ON_TEMPO.
+    function test_mixedMapping_ethToTempo_inboxKeyedByERC20() public {
+        // On the ETH side: localToken = NATIVE_TOKEN, remoteToken = WETH_ON_TEMPO
+        // When _sendRoot constructs the message, root.token = remoteToken.addr = WETH_ON_TEMPO
+        // On Tempo side: fromRemote receives root.token = WETH_ON_TEMPO
+
+        JBMessageRoot memory root = JBMessageRoot({
+            token: WETH_ON_TEMPO, // This is what the Tempo sucker receives
+            amount: 5 ether,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xAABBCC))})
+        });
+
+        // Simulate fromRemote call from the peer (self for test sucker)
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(root);
+
+        // The inbox should be keyed by WETH_ON_TEMPO (ERC20), NOT by NATIVE_TOKEN
+        assertEq(tempoSucker.test_getInboxNonce(WETH_ON_TEMPO), 1, "Inbox nonce for WETH_ON_TEMPO should be 1");
+        assertEq(
+            tempoSucker.test_getInboxRoot(WETH_ON_TEMPO),
+            bytes32(uint256(0xAABBCC)),
+            "Inbox root should match for WETH_ON_TEMPO"
+        );
+
+        // NATIVE_TOKEN inbox should remain untouched
+        assertEq(tempoSucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN), 0, "NATIVE_TOKEN inbox should be empty");
+    }
+
+    // =========================================================================
+    // Test 2: Mixed NATIVE/ERC20 mapping — Tempo→ETH direction
+    // =========================================================================
+    /// @notice When WETH_ON_TEMPO (ERC20) on Tempo maps to NATIVE_TOKEN on ETH, the ETH sucker
+    ///         receives root.token = NATIVE_TOKEN, triggering the WETH unwrap path.
+    function test_mixedMapping_tempoToEth_inboxKeyedByNativeToken() public {
+        // On Tempo side: localToken = WETH_ON_TEMPO, remoteToken = NATIVE_TOKEN
+        // When _sendRoot constructs message, root.token = remoteToken.addr = NATIVE_TOKEN
+        // On ETH side: fromRemote receives root.token = NATIVE_TOKEN
+
+        JBMessageRoot memory root = JBMessageRoot({
+            token: JBConstants.NATIVE_TOKEN, // ETH sucker receives NATIVE_TOKEN
+            amount: 5 ether,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xDDEEFF))})
+        });
+
+        // Simulate fromRemote on ETH side
+        vm.prank(address(ethSucker));
+        ethSucker.fromRemote(root);
+
+        // Inbox should be keyed by NATIVE_TOKEN
+        assertEq(ethSucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN), 1, "Inbox nonce for NATIVE_TOKEN should be 1");
+        assertEq(
+            ethSucker.test_getInboxRoot(JBConstants.NATIVE_TOKEN),
+            bytes32(uint256(0xDDEEFF)),
+            "Inbox root should match for NATIVE_TOKEN"
+        );
+    }
+
+    // =========================================================================
+    // Test 3: Double-claim prevention on mixed NATIVE/ERC20 mapping
+    // =========================================================================
+    /// @notice Verify that claiming the same leaf twice reverts, even when the token mapping
+    ///         is mixed (NATIVE_TOKEN on one side, ERC20 on the other).
+    function test_doubleClaim_mixedMapping() public {
+        address token = WETH_ON_TEMPO; // ERC20 on Tempo side
+
+        // Insert a leaf for WETH_ON_TEMPO
+        tempoSucker.test_insertIntoTree(5 ether, token, 5 ether, address(120));
+        bytes32 root = tempoSucker.test_getOutboxRoot(token);
+        tempoSucker.test_setInboxRoot(token, 1, root);
+        tempoSucker.test_setOutboxBalance(token, 100 ether);
+
+        // Mock controller for minting
+        vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.controllerOf, (PROJECT_ID)), abi.encode(CONTROLLER));
+        vm.mockCall(
+            CONTROLLER,
+            abi.encodeCall(IJBController.mintTokensOf, (PROJECT_ID, 5 ether, address(120), "", false)),
+            abi.encode(5 ether)
+        );
+
+        // First claim succeeds
+        tempoSucker.test_setNextMerkleCheckToBe(true);
+        bytes32[32] memory proof;
+        JBClaim memory claimData = JBClaim({
+            token: token,
+            leaf: JBLeaf({index: 0, beneficiary: address(120), projectTokenCount: 5 ether, terminalTokenAmount: 5 ether}),
+            proof: proof
+        });
+        tempoSucker.claim(claimData);
+
+        // Second claim with same index must revert
+        vm.expectRevert(abi.encodeWithSelector(JBSucker.JBSucker_LeafAlreadyExecuted.selector, token, 0));
+        tempoSucker.claim(claimData);
+    }
+
+    // =========================================================================
+    // Test 4: WTEMP ≠ WETH — wrapped native mismatch
+    // =========================================================================
+    /// @notice WTEMP (wrapped native USD on Tempo) and WETH (wrapped ETH on Tempo) are different tokens.
+    ///         Verify that inbox roots are correctly segregated by token address.
+    function test_wrappedNativeMismatch_wtempNotWeth() public {
+        // WTEMP and WETH_ON_TEMPO are completely different tokens
+        assertTrue(WTEMP != WETH_ON_TEMPO, "WTEMP and WETH_ON_TEMPO must be different addresses");
+
+        // Set up separate inbox roots for WTEMP and WETH_ON_TEMPO
+        tempoSucker.test_setInboxRoot(WTEMP, 1, bytes32(uint256(0x111)));
+        tempoSucker.test_setInboxRoot(WETH_ON_TEMPO, 1, bytes32(uint256(0x222)));
+
+        // Verify they are independently tracked
+        assertEq(tempoSucker.test_getInboxRoot(WTEMP), bytes32(uint256(0x111)), "WTEMP inbox should be independent");
+        assertEq(
+            tempoSucker.test_getInboxRoot(WETH_ON_TEMPO),
+            bytes32(uint256(0x222)),
+            "WETH inbox should be independent"
+        );
+
+        // Setting one should not affect the other
+        tempoSucker.test_setInboxRoot(WTEMP, 2, bytes32(uint256(0x333)));
+        assertEq(
+            tempoSucker.test_getInboxRoot(WETH_ON_TEMPO),
+            bytes32(uint256(0x222)),
+            "Updating WTEMP should not affect WETH inbox"
+        );
+    }
+
+    // =========================================================================
+    // Test 5: Round-trip bridge accounting (ETH→Tempo→ETH)
+    // =========================================================================
+    /// @notice Verify that outbox trees and inbox roots remain consistent during a round-trip bridge.
+    ///         ETH→Tempo (as WETH ERC20) → back to ETH (as NATIVE_TOKEN).
+    function test_roundTripAccounting() public {
+        // === Leg 1: ETH → Tempo ===
+        // On ETH side, user prepares NATIVE_TOKEN for bridging
+        ethSucker.test_insertIntoTree(10 ether, JBConstants.NATIVE_TOKEN, 5 ether, address(1000));
+        bytes32 ethOutboxRoot = ethSucker.test_getOutboxRoot(JBConstants.NATIVE_TOKEN);
+        uint256 ethOutboxCount = ethSucker.test_getOutboxCount(JBConstants.NATIVE_TOKEN);
+        assertEq(ethOutboxCount, 1, "ETH outbox should have 1 leaf");
+
+        // Simulate: root arrives on Tempo as WETH_ON_TEMPO (the remote token addr)
+        JBMessageRoot memory toTempoMsg = JBMessageRoot({
+            token: WETH_ON_TEMPO,
+            amount: 5 ether,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: ethOutboxRoot})
+        });
+
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(toTempoMsg);
+        assertEq(tempoSucker.test_getInboxNonce(WETH_ON_TEMPO), 1, "Tempo inbox nonce should be 1");
+
+        // === Leg 2: Tempo → ETH ===
+        // On Tempo side, user prepares WETH_ON_TEMPO for bridging back
+        tempoSucker.test_insertIntoTree(10 ether, WETH_ON_TEMPO, 5 ether, address(2000));
+        bytes32 tempoOutboxRoot = tempoSucker.test_getOutboxRoot(WETH_ON_TEMPO);
+        uint256 tempoOutboxCount = tempoSucker.test_getOutboxCount(WETH_ON_TEMPO);
+        assertEq(tempoOutboxCount, 1, "Tempo outbox should have 1 leaf");
+
+        // Simulate: root arrives on ETH as NATIVE_TOKEN (the remote token addr)
+        JBMessageRoot memory toEthMsg = JBMessageRoot({
+            token: JBConstants.NATIVE_TOKEN,
+            amount: 5 ether,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: tempoOutboxRoot})
+        });
+
+        vm.prank(address(ethSucker));
+        ethSucker.fromRemote(toEthMsg);
+        assertEq(ethSucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN), 1, "ETH inbox nonce should be 1");
+
+        // Verify: Both sides have correct inbox roots from the round-trip
+        assertEq(
+            tempoSucker.test_getInboxRoot(WETH_ON_TEMPO), ethOutboxRoot, "Tempo inbox should hold ETH outbox root"
+        );
+        assertEq(
+            ethSucker.test_getInboxRoot(JBConstants.NATIVE_TOKEN),
+            tempoOutboxRoot,
+            "ETH inbox should hold Tempo outbox root"
+        );
+    }
+
+    // =========================================================================
+    // Test 6: Nonce replay prevention across mixed token types
+    // =========================================================================
+    /// @notice Verify that replaying a message with the same nonce is silently ignored,
+    ///         even when crossing between NATIVE_TOKEN and ERC20 token types.
+    function test_nonceReplay_mixedTokenTypes() public {
+        JBMessageRoot memory root = JBMessageRoot({
+            token: WETH_ON_TEMPO,
+            amount: 5 ether,
+            remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xAABBCC))})
+        });
+
+        // First delivery — accepted
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(root);
+        assertEq(tempoSucker.test_getInboxNonce(WETH_ON_TEMPO), 1);
+
+        // Replay with same nonce — silently ignored
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(root);
+        assertEq(tempoSucker.test_getInboxNonce(WETH_ON_TEMPO), 1, "Nonce should not advance on replay");
+
+        // Higher nonce — accepted
+        root.remoteRoot.nonce = 2;
+        root.remoteRoot.root = bytes32(uint256(0xDDEEFF));
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(root);
+        assertEq(tempoSucker.test_getInboxNonce(WETH_ON_TEMPO), 2, "Nonce should advance to 2");
+    }
+
+    // =========================================================================
+    // Test 7: Outbox tree isolation between NATIVE_TOKEN and WETH_ON_TEMPO
+    // =========================================================================
+    /// @notice On Tempo, NATIVE_TOKEN (USD) and WETH_ON_TEMPO (ETH as ERC20) are different tokens
+    ///         with separate outbox trees. Inserting into one should not affect the other.
+    function test_outboxTreeIsolation_nativeVsWeth() public {
+        // Insert into NATIVE_TOKEN (USD) outbox
+        tempoSucker.test_insertIntoTree(1 ether, JBConstants.NATIVE_TOKEN, 1 ether, address(100));
+
+        // Insert into WETH_ON_TEMPO outbox
+        tempoSucker.test_insertIntoTree(2 ether, WETH_ON_TEMPO, 2 ether, address(200));
+
+        // Verify separate tree counts
+        assertEq(tempoSucker.test_getOutboxCount(JBConstants.NATIVE_TOKEN), 1, "NATIVE outbox should have 1 leaf");
+        assertEq(tempoSucker.test_getOutboxCount(WETH_ON_TEMPO), 1, "WETH outbox should have 1 leaf");
+
+        // Verify separate roots
+        bytes32 nativeRoot = tempoSucker.test_getOutboxRoot(JBConstants.NATIVE_TOKEN);
+        bytes32 wethRoot = tempoSucker.test_getOutboxRoot(WETH_ON_TEMPO);
+        assertTrue(nativeRoot != wethRoot, "NATIVE and WETH outbox roots should differ");
+    }
+
+    // =========================================================================
+    // Test 8: CCIPHelper constants for Tempo testnet
+    // =========================================================================
+    /// @notice Verify that the CCIPHelper library returns correct constants for Tempo testnet.
+    function test_ccipHelper_tempoTestnetConstants() public pure {
+        // Verify chain ID
+        assertEq(CCIPHelper.TEMPO_TEST_ID, 42_429, "Tempo testnet chain ID should be 42429");
+
+        // Verify selector
+        assertEq(
+            CCIPHelper.TEMPO_TEST_SEL,
+            3_963_528_237_232_804_922,
+            "Tempo testnet CCIP selector should match"
+        );
+
+        // Verify router
+        assertEq(
+            CCIPHelper.TEMPO_TEST_ROUTER,
+            0xAE7D1b3D8466718378038de45D4D376E73A04EB6,
+            "Tempo testnet router should match"
+        );
+
+        // Verify WTEMP address
+        assertEq(
+            CCIPHelper.TEMPO_TEST_WETH,
+            0xe875EB5437E55B74D18f6C090a5A14e4804dB2d9,
+            "Tempo testnet WTEMP should match"
+        );
+
+        // Verify lookup functions
+        assertEq(CCIPHelper.routerOfChain(42_429), CCIPHelper.TEMPO_TEST_ROUTER, "routerOfChain should match");
+        assertEq(CCIPHelper.selectorOfChain(42_429), CCIPHelper.TEMPO_TEST_SEL, "selectorOfChain should match");
+        assertEq(CCIPHelper.wethOfChain(42_429), CCIPHelper.TEMPO_TEST_WETH, "wethOfChain should match");
+    }
+
+    // =========================================================================
+    // Test 9: Emergency exit with mixed token mapping
+    // =========================================================================
+    /// @notice Verify emergency exit works correctly when the sucker on Tempo uses WETH_ON_TEMPO
+    ///         (an ERC20 token that maps to NATIVE_TOKEN on ETH).
+    function test_emergencyExit_mixedMapping() public {
+        address token = WETH_ON_TEMPO;
+
+        // Set up a remote mapping: WETH_ON_TEMPO → NATIVE_TOKEN on ETH
+        tempoSucker.test_setRemoteToken(
+            token,
+            JBRemoteToken({enabled: true, emergencyHatch: false, minGas: 200_000, addr: JBConstants.NATIVE_TOKEN, minBridgeAmount: 0})
+        );
+
+        // Insert leaf and set inbox root
+        tempoSucker.test_insertIntoTree(1 ether, token, 1 ether, address(this));
+        bytes32 root = tempoSucker.test_getOutboxRoot(token);
+        tempoSucker.test_setInboxRoot(token, 1, root);
+        tempoSucker.test_setOutboxBalance(token, 10 ether);
+
+        // Deprecate the sucker
+        uint256 deprecationTimestamp = block.timestamp + 14 days;
+        tempoSucker.setDeprecation(uint40(deprecationTimestamp));
+        vm.warp(deprecationTimestamp);
+
+        // Mock controller for minting
+        vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.controllerOf, (PROJECT_ID)), abi.encode(CONTROLLER));
+        vm.mockCall(
+            CONTROLLER,
+            abi.encodeCall(IJBController.mintTokensOf, (PROJECT_ID, 1 ether, address(this), "", false)),
+            abi.encode(1 ether)
+        );
+
+        // Bypass merkle validation for this test
+        tempoSucker.test_setNextMerkleCheckToBe(true);
+
+        bytes32[32] memory proof;
+        JBClaim memory claim = JBClaim({
+            token: token,
+            leaf: JBLeaf({
+                index: 0,
+                beneficiary: address(this),
+                projectTokenCount: 1 ether,
+                terminalTokenAmount: 1 ether
+            }),
+            proof: proof
+        });
+
+        // Emergency exit should work for ERC20 token (WETH_ON_TEMPO) on Tempo
+        tempoSucker.exitThroughEmergencyHatch(claim);
+    }
+
+    // =========================================================================
+    // Test 10: Independent nonce tracking for different token types
+    // =========================================================================
+    /// @notice Verify that NATIVE_TOKEN and WETH_ON_TEMPO have independent nonce tracking
+    ///         in the inbox, preventing cross-token nonce confusion.
+    function test_independentNonceTracking() public {
+        // Deliver message for WETH_ON_TEMPO at nonce 1
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(
+            JBMessageRoot({
+                token: WETH_ON_TEMPO,
+                amount: 1 ether,
+                remoteRoot: JBInboxTreeRoot({nonce: 1, root: bytes32(uint256(0xAA))})
+            })
+        );
+
+        // Deliver message for NATIVE_TOKEN at nonce 5 (independent nonce space)
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(
+            JBMessageRoot({
+                token: JBConstants.NATIVE_TOKEN,
+                amount: 1 ether,
+                remoteRoot: JBInboxTreeRoot({nonce: 5, root: bytes32(uint256(0xBB))})
+            })
+        );
+
+        // Verify independent nonce tracking
+        assertEq(tempoSucker.test_getInboxNonce(WETH_ON_TEMPO), 1, "WETH nonce should be 1");
+        assertEq(tempoSucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN), 5, "NATIVE nonce should be 5");
+
+        // Advancing NATIVE nonce should not affect WETH nonce
+        vm.prank(address(tempoSucker));
+        tempoSucker.fromRemote(
+            JBMessageRoot({
+                token: JBConstants.NATIVE_TOKEN,
+                amount: 1 ether,
+                remoteRoot: JBInboxTreeRoot({nonce: 6, root: bytes32(uint256(0xCC))})
+            })
+        );
+        assertEq(tempoSucker.test_getInboxNonce(WETH_ON_TEMPO), 1, "WETH nonce should still be 1");
+        assertEq(tempoSucker.test_getInboxNonce(JBConstants.NATIVE_TOKEN), 6, "NATIVE nonce should advance to 6");
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
## Summary
- Add Tempo testnet constants to `CCIPHelper.sol` (router, chain ID, selector, WTEMP address)
- Add CCIP sucker deployers for Tempo <-> ETH/OP/BASE/ARB bridging in `Deploy.s.sol`
- Add `tempoDeployer` field to `SuckerDeployment` struct
- Add security tests (`TempoSuckerSecurity.t.sol` — 10 tests, `TempoAttacks.t.sol` — 9 tests)
- Add Tempo testnet RPC endpoint to `foundry.toml`

## Context
Tempo is an L1 blockchain where the native token is USD (not ETH). Key design decisions:
- ETH-denominated projects use NATIVE_TOKEN on ETH chains and WETH (ERC20) on Tempo
- Only `JBCCIPSucker` supports mixed NATIVE_TOKEN <-> ERC20 token mappings (base `JBSucker._validateTokenMapping()` rejects these)
- CCIP fees on Tempo are paid in native USD (`feeToken: address(0)`)
- Testnet only for now (chain ID 42429, CCIP selector 3963528237232804922)

## Audit findings
- `_validateTokenMapping()` in `JBSucker.sol:301` enforces NATIVE_TOKEN must map to NATIVE_TOKEN — only `JBCCIPSucker` overrides this
- WTEMP (wrapped USD) is distinct from WETH on Tempo — sucker must not confuse them
- Deprecated sucker message injection is properly blocked by timestamp validation

## Test plan
- [x] All 10 `TempoSuckerSecurity` tests pass
- [x] All 9 `TempoAttacks` tests pass
- [x] All existing tests pass (no regressions)
- [ ] Verify CCIP testnet configuration matches Chainlink's directory
- [ ] Test against Tempo testnet when RPC is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)