### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -24,15 +24,15 @@ contract DeployScript is Script, Sphinx {
     address TRUSTED_FORWARDER;
 
     /// @notice the nonces that are used to deploy the contracts.
-    bytes32 OP_SALT = "_SUCKER_ETH_OP_";
-    bytes32 BASE_SALT = "_SUCKER_ETH_BASE_";
-    bytes32 ARB_SALT = "_SUCKER_ETH_ARB_";
+    bytes32 OP_SALT = "_SUCKER_ETH_OP_V6_";
+    bytes32 BASE_SALT = "_SUCKER_ETH_BASE_V6_";
+    bytes32 ARB_SALT = "_SUCKER_ETH_ARB_V6_";
 
-    bytes32 ARB_BASE_SALT = "_SUCKER_ARB_BASE_";
-    bytes32 ARB_OP_SALT = "_SUCKER_ARB_OP_";
-    bytes32 OP_BASE_SALT = "_SUCKER_OP_BASE_";
+    bytes32 ARB_BASE_SALT = "_SUCKER_ARB_BASE_V6_";
+    bytes32 ARB_OP_SALT = "_SUCKER_ARB_OP_V6_";
+    bytes32 OP_BASE_SALT = "_SUCKER_OP_BASE_V6_";
 
-    bytes32 REGISTRY_SALT = "REGISTRY";
+    bytes32 REGISTRY_SALT = "REGISTRYV6";
 
     function configureSphinx() public override {
         // TODO: Update to contain JB Emergency Developers


### PR DESCRIPTION
## Summary
- Updated all sucker chain-pair salts (`OP_SALT`, `BASE_SALT`, `ARB_SALT`, `ARB_BASE_SALT`, `ARB_OP_SALT`, `OP_BASE_SALT`) with V6 suffix
- Updated `REGISTRY_SALT` from `REGISTRY` to `REGISTRYV6`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)