### PR TITLE
chore: standardize slither CI, convert positional args to named params

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +21,7 @@ jobs:
         with:
           node-version: latest
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --production
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run slither

--- a/src/JBArbitrumSucker.sol
+++ b/src/JBArbitrumSucker.sol
@@ -143,9 +143,15 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         // Depending on which layer we are on, send the call to the other layer.
         // slither-disable-start out-of-order-retryable
         if (LAYER == JBLayer.L1) {
-            _toL2(token, transportPayment, amount, data, remoteToken);
+            _toL2({
+                token: token,
+                transportPayment: transportPayment,
+                amount: amount,
+                data: data,
+                remoteToken: remoteToken
+            });
         } else {
-            _toL1(token, amount, data, remoteToken);
+            _toL1({token: token, amount: amount, data: data, remoteToken: remoteToken});
         }
         // slither-disable-end out-of-order-retryable
     }
@@ -187,7 +193,7 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         // Address `100` is the ArbSys precompile address.
         // Convert bytes32 peer to address at the Arbitrum API boundary.
         // slither-disable-next-line calls-loop,unused-return
-        ArbSys(address(100)).sendTxToL1{value: nativeValue}(_toAddress(peer()), data);
+        ArbSys(address(100)).sendTxToL1{value: nativeValue}({destination: _toAddress(peer()), data: data});
     }
 
     /// @notice Bridge the `token` and data to the remote L2 chain.
@@ -274,7 +280,13 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
 
         // Convert bytes32 peer to address at the Arbitrum inbox API boundary.
         // slither-disable-next-line calls-loop,unused-return
-        _createRetryableTicket(callTransportCost, nativeValue, maxSubmissionCost, maxFeePerGas, data);
+        _createRetryableTicket({
+            callTransportCost: callTransportCost,
+            nativeValue: nativeValue,
+            maxSubmissionCost: maxSubmissionCost,
+            maxFeePerGas: maxFeePerGas,
+            data: data
+        });
         // slither-disable-end out-of-order-retryable
     }
 

--- a/src/JBOptimismSucker.sol
+++ b/src/JBOptimismSucker.sol
@@ -134,8 +134,10 @@ contract JBOptimismSucker is JBSucker, IJBOptimismSucker {
         // Send the message to the peer with the reclaimed ETH.
         // Convert bytes32 peer to address at the OP Messenger API boundary.
         // slither-disable-next-line arbitrary-send-eth,reentrancy-events,calls-loop
-        OPMESSENGER.sendMessage{value: nativeValue}(
-            _toAddress(peer()), abi.encodeCall(JBSucker.fromRemote, (message)), MESSENGER_BASE_GAS_LIMIT
-        );
+        OPMESSENGER.sendMessage{value: nativeValue}({
+            target: _toAddress(peer()),
+            message: abi.encodeCall(JBSucker.fromRemote, (message)),
+            gasLimit: MESSENGER_BASE_GAS_LIMIT
+        });
     }
 }

--- a/src/JBSucker.sol
+++ b/src/JBSucker.sol
@@ -187,7 +187,7 @@ abstract contract JBSucker is ERC2771Context, JBPermissioned, Initializable, ERC
     /// @param token The local terminal token to get the amount to add to balance for.
     function amountToAddToBalanceOf(address token) public view override returns (uint256) {
         // Get the amount that is in this sucker to be bridged.
-        return _balanceOf(token, address(this)) - _outboxOf[token].balance;
+        return _balanceOf({token: token, addr: address(this)}) - _outboxOf[token].balance;
     }
 
     /// @notice The inbox merkle tree root for a given token.
@@ -927,7 +927,7 @@ abstract contract JBSucker is ERC2771Context, JBPermissioned, Initializable, ERC
         }
 
         // Cash out the tokens.
-        uint256 balanceBefore = _balanceOf(token, address(this));
+        uint256 balanceBefore = _balanceOf({token: token, addr: address(this)});
         reclaimedAmount = terminal.cashOutTokensOf({
             holder: address(this),
             projectId: _projectId,
@@ -990,7 +990,14 @@ abstract contract JBSucker is ERC2771Context, JBPermissioned, Initializable, ERC
         });
 
         // Execute the chain/sucker specific logic for transferring the assets and communicating the root.
-        _sendRootOverAMB(transportPayment, index, token, amount, remoteToken, message);
+        _sendRootOverAMB({
+            transportPayment: transportPayment,
+            index: index,
+            token: token,
+            amount: amount,
+            remoteToken: remoteToken,
+            message: message
+        });
     }
 
     /// @notice Performs the logic to send a message to the peer over the AMB.
@@ -1049,9 +1056,14 @@ abstract contract JBSucker is ERC2771Context, JBPermissioned, Initializable, ERC
 
         // Calculate the root based on the leaf, the branch, and the index.
         // Compare to the current root, Revert if they do not match.
-        _validateBranchRoot(
-            _inboxOf[terminalToken].root, projectTokenCount, terminalTokenAmount, beneficiary, index, leaves
-        );
+        _validateBranchRoot({
+            expectedRoot: _inboxOf[terminalToken].root,
+            projectTokenCount: projectTokenCount,
+            terminalTokenAmount: terminalTokenAmount,
+            beneficiary: beneficiary,
+            index: index,
+            leaves: leaves
+        });
     }
 
     /// @notice Validates a leaf as being in the outbox merkle tree and not being send over the amb, and registers the
@@ -1128,9 +1140,14 @@ abstract contract JBSucker is ERC2771Context, JBPermissioned, Initializable, ERC
 
         // Calculate the root based on the leaf, the branch, and the index.
         // Compare to the current root, Revert if they do not match.
-        _validateBranchRoot(
-            _outboxOf[terminalToken].tree.root(), projectTokenCount, terminalTokenAmount, beneficiary, index, leaves
-        );
+        _validateBranchRoot({
+            expectedRoot: _outboxOf[terminalToken].tree.root(),
+            projectTokenCount: projectTokenCount,
+            terminalTokenAmount: terminalTokenAmount,
+            beneficiary: beneficiary,
+            index: index,
+            leaves: leaves
+        });
     }
 
     /// @notice Validates a branch root against the expected root.


### PR DESCRIPTION
## Summary
- Standardize slither workflow (add `NODE_ENV: production`, `npm ci --production`)
- Convert 9 positional function calls to named parameters across JBSucker, JBArbitrumSucker, JBOptimismSucker

## Test plan
- [x] `forge build` passes
- [ ] `forge test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)